### PR TITLE
feat: XBRL dimensional support for a1204s1

### DIFF
--- a/app/models/survey/fields/customer_risk.rb
+++ b/app/models/survey/fields/customer_risk.rb
@@ -505,6 +505,7 @@ class Survey
       # === Dimensional Breakdowns (by nationality/country) ===
 
       # BO nationality breakdown (percentages)
+      # Returns Hash of ISO country code => percentage for XBRL dimensional output
       def a1204s1
         counts = beneficial_owners_base
           .where.not(nationality: [nil, ""])
@@ -512,13 +513,9 @@ class Survey
           .count
 
         total = counts.values.sum.to_f
-        return "" if total.zero?
+        return {} if total.zero?
 
-        counts.map do |code, count|
-          percentage = (count / total * 100).round(0)
-          country_name = ISO3166::Country[code]&.common_name || code
-          "#{country_name}: #{percentage}%"
-        end.join(", ")
+        counts.transform_values { |count| (count / total * 100).round(2) }
       end
 
       # BOs by direct/indirect and nationality


### PR DESCRIPTION
## Summary
- Update `a1204s1` to return `Hash<country_code, percentage>` instead of formatted string
- This enables proper XBRL dimensional output for nationality breakdown field
- The `amsf_survey` gem (updated separately) generates contexts with `xbrldi:explicitMember` segments

## XBRL Output
Before: `a1204S1` validation failed with "lexical pattern mismatch" error because it expected a decimal, not a formatted string.

After: Generates multiple facts, one per nationality:
```xml
<strix:a1204S1 contextRef="ctx_ENTITY_2025_FR" unitRef="pure" decimals="2">9.09</strix:a1204S1>
<strix:a1204S1 contextRef="ctx_ENTITY_2025_MC" unitRef="pure" decimals="2">24.24</strix:a1204S1>
```

## Test plan
- [x] Survey tests pass (`bin/rails test test/models/survey_test.rb`)
- [x] XBRL generation includes dimensional contexts
- [ ] Arelle validation passes (requires gem deployment)

🤖 Generated with [Claude Code](https://claude.ai/code)