### PR TITLE
feat: add service layer, CRM API, and CLI for AI agent integration

### DIFF
--- a/app/controllers/api/v1/api_organization_scoped.rb
+++ b/app/controllers/api/v1/api_organization_scoped.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Provides organization scoping for API v1 controllers.
+# Mirrors OrganizationScoped concern used by web controllers.
+module Api
+  module V1
+    module ApiOrganizationScoped
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :require_organization
+      end
+
+      private
+
+      def current_organization
+        @current_organization ||= current_account&.organization
+      end
+
+      def current_account
+        Current.account
+      end
+
+      def require_organization
+        return if current_organization.present?
+
+        render json: { error: "No organization found for this account" }, status: :unprocessable_entity
+      end
+
+      # Standard JSON error response from a ServiceResult
+      def render_service_result(result, status: :ok, created_status: :created)
+        if result.success?
+          if result.record.is_a?(ActiveRecord::Base)
+            render json: serialize_record(result.record), status: created_status
+          else
+            render json: result.record, status: status
+          end
+        else
+          render json: { errors: result.errors }, status: :unprocessable_entity
+        end
+      end
+
+      # Override in controllers for custom serialization
+      def serialize_record(record)
+        record.as_json
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/beneficial_owners_controller.rb
+++ b/app/controllers/api/v1/beneficial_owners_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class BeneficialOwnersController < Api::BaseController
+      include ApiOrganizationScoped
+
+      before_action :set_client, only: [:index, :create]
+      before_action :set_beneficial_owner, only: [:show, :update, :destroy]
+
+      # GET /api/v1/clients/:client_id/beneficial_owners
+      def index
+        authorize BeneficialOwner
+        render json: @client.beneficial_owners.as_json
+      end
+
+      # GET /api/v1/beneficial_owners/:id
+      def show
+        authorize @beneficial_owner
+        render json: @beneficial_owner.as_json
+      end
+
+      # POST /api/v1/clients/:client_id/beneficial_owners
+      def create
+        owner = @client.beneficial_owners.build(beneficial_owner_params)
+        authorize owner
+
+        if owner.save
+          render json: owner.as_json, status: :created
+        else
+          render json: { errors: owner.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/beneficial_owners/:id
+      def update
+        authorize @beneficial_owner
+
+        if @beneficial_owner.update(beneficial_owner_params)
+          render json: @beneficial_owner.as_json
+        else
+          render json: { errors: @beneficial_owner.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/beneficial_owners/:id
+      def destroy
+        authorize @beneficial_owner
+        @beneficial_owner.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_client
+        @client = policy_scope(Client).find_by(id: params[:client_id])
+        return render json: { error: "Client not found" }, status: :not_found unless @client
+        return render json: { error: "Client cannot have beneficial owners" }, status: :unprocessable_entity unless @client.can_have_beneficial_owners?
+      end
+
+      def set_beneficial_owner
+        @beneficial_owner = BeneficialOwner.find_by(id: params[:id])
+        return render json: { error: "Beneficial owner not found" }, status: :not_found unless @beneficial_owner
+
+        @client = @beneficial_owner.client
+        return render json: { error: "Not authorized" }, status: :not_found unless policy_scope(Client).exists?(id: @client.id)
+      end
+
+      def beneficial_owner_params
+        params.require(:beneficial_owner).permit(
+          BeneficialOwnerPolicy.new(pundit_user, BeneficialOwner).permitted_attributes
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/clients_controller.rb
+++ b/app/controllers/api/v1/clients_controller.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ClientsController < Api::BaseController
+      include ApiOrganizationScoped
+
+      before_action :set_client, only: [:show, :update, :destroy, :assess_risk]
+
+      # GET /api/v1/clients
+      def index
+        clients = policy_scope(Client).includes(:beneficial_owners)
+        clients = clients.where(client_type: params[:client_type]) if params[:client_type].present?
+        clients = clients.where(risk_level: params[:risk_level]) if params[:risk_level].present?
+        clients = clients.search(params[:q]) if params[:q].present?
+        clients = clients.order(created_at: :desc)
+
+        render json: clients.map { |c| serialize_client(c) }
+      end
+
+      # GET /api/v1/clients/:id
+      def show
+        authorize @client
+        render json: serialize_client(@client, include_owners: true)
+      end
+
+      # POST /api/v1/clients
+      def create
+        result = Clients::Create.call(
+          organization: current_organization,
+          params: client_params
+        )
+
+        if result.success?
+          render json: serialize_client(result.record), status: :created
+        else
+          render json: { errors: result.errors }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/clients/:id
+      def update
+        authorize @client
+
+        result = Clients::Update.call(client: @client, params: client_params)
+
+        if result.success?
+          render json: serialize_client(result.record)
+        else
+          render json: { errors: result.errors }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/clients/:id
+      def destroy
+        authorize @client
+        @client.discard
+        head :no_content
+      end
+
+      # POST /api/v1/clients/onboard
+      def onboard
+        result = Clients::Onboard.call(
+          organization: current_organization,
+          client_params: client_params,
+          beneficial_owners: params[:beneficial_owners]&.map { |bo| bo.permit(*beneficial_owner_attrs) } || []
+        )
+
+        if result.success?
+          render json: serialize_client(result.record, include_owners: true), status: :created
+        else
+          render json: { errors: result.errors }, status: :unprocessable_entity
+        end
+      end
+
+      # GET /api/v1/clients/:id/assess_risk
+      def assess_risk
+        authorize @client, :show?
+
+        result = Clients::AssessRisk.call(client: @client)
+        render json: result.record
+      end
+
+      private
+
+      def set_client
+        @client = policy_scope(Client.with_discarded).find_by(id: params[:id])
+        render json: { error: "Client not found" }, status: :not_found unless @client
+      end
+
+      def client_params
+        params.require(:client).permit(ClientPolicy.new(pundit_user, Client).permitted_attributes)
+      end
+
+      def beneficial_owner_attrs
+        BeneficialOwnerPolicy.new(pundit_user, BeneficialOwner).permitted_attributes
+      end
+
+      def serialize_client(client, include_owners: false)
+        data = client.as_json(except: [:deleted_at])
+        if include_owners && client.can_have_beneficial_owners?
+          data["beneficial_owners"] = client.beneficial_owners.as_json
+        end
+        data
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/compliance_controller.rb
+++ b/app/controllers/api/v1/compliance_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ComplianceController < Api::BaseController
+      include ApiOrganizationScoped
+
+      # GET /api/v1/compliance/gaps
+      def gaps
+        year = params[:year]&.to_i || Date.current.year
+        result = Compliance::Gaps.call(organization: current_organization, year: year)
+        render json: result.record
+      end
+
+      # GET /api/v1/compliance/risk_assessment
+      def risk_assessment
+        year = params[:year]&.to_i || Date.current.year
+        result = Compliance::RiskAssessment.call(organization: current_organization, year: year)
+        render json: result.record
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/managed_properties_controller.rb
+++ b/app/controllers/api/v1/managed_properties_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ManagedPropertiesController < Api::BaseController
+      include ApiOrganizationScoped
+
+      before_action :set_managed_property, only: [:show, :update, :destroy]
+
+      # GET /api/v1/managed_properties
+      def index
+        properties = policy_scope(ManagedProperty).includes(:client)
+        properties = properties.where(property_type: params[:property_type]) if params[:property_type].present?
+
+        if params[:status] == "active"
+          properties = properties.active
+        elsif params[:status] == "ended"
+          properties = properties.ended
+        end
+
+        properties = properties.order(management_start_date: :desc)
+
+        render json: properties.as_json(include: { client: { only: [:id, :name] } })
+      end
+
+      # GET /api/v1/managed_properties/:id
+      def show
+        authorize @managed_property
+        render json: @managed_property.as_json(include: { client: { only: [:id, :name] } })
+      end
+
+      # POST /api/v1/managed_properties
+      def create
+        property = current_organization.managed_properties.build(managed_property_params)
+        authorize property
+
+        if property.save
+          render json: property.as_json, status: :created
+        else
+          render json: { errors: property.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/managed_properties/:id
+      def update
+        authorize @managed_property
+
+        if @managed_property.update(managed_property_params)
+          render json: @managed_property.as_json
+        else
+          render json: { errors: @managed_property.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/managed_properties/:id
+      def destroy
+        authorize @managed_property
+        @managed_property.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_managed_property
+        @managed_property = policy_scope(ManagedProperty).find_by(id: params[:id])
+        render json: { error: "Managed property not found" }, status: :not_found unless @managed_property
+      end
+
+      def managed_property_params
+        params.require(:managed_property).permit(
+          ManagedPropertyPolicy.new(pundit_user, ManagedProperty).permitted_attributes
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/str_reports_controller.rb
+++ b/app/controllers/api/v1/str_reports_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class StrReportsController < Api::BaseController
+      include ApiOrganizationScoped
+
+      before_action :set_str_report, only: [:show, :update, :destroy]
+
+      # GET /api/v1/str_reports
+      def index
+        reports = policy_scope(StrReport).includes(:client, :linked_transaction)
+        reports = reports.for_year(params[:year].to_i) if params[:year].present?
+        reports = reports.by_reason(params[:reason]) if params[:reason].present?
+        reports = reports.recent
+
+        render json: reports.as_json(include: {
+          client: { only: [:id, :name] },
+          linked_transaction: { only: [:id, :transaction_type, :transaction_date] }
+        })
+      end
+
+      # GET /api/v1/str_reports/:id
+      def show
+        authorize @str_report
+        render json: @str_report.as_json(include: {
+          client: { only: [:id, :name] },
+          linked_transaction: { only: [:id, :transaction_type, :transaction_date] }
+        })
+      end
+
+      # POST /api/v1/str_reports
+      def create
+        report = current_organization.str_reports.build(str_report_params)
+        authorize report
+
+        if report.save
+          render json: report.as_json, status: :created
+        else
+          render json: { errors: report.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/str_reports/:id
+      def update
+        authorize @str_report
+
+        if @str_report.update(str_report_params)
+          render json: @str_report.as_json
+        else
+          render json: { errors: @str_report.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/str_reports/:id
+      def destroy
+        authorize @str_report
+        @str_report.discard
+        head :no_content
+      end
+
+      private
+
+      def set_str_report
+        @str_report = policy_scope(StrReport.with_discarded).find_by(id: params[:id])
+        render json: { error: "STR report not found" }, status: :not_found unless @str_report
+      end
+
+      def str_report_params
+        params.require(:str_report).permit(
+          StrReportPolicy.new(pundit_user, StrReport).permitted_attributes
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/submissions_controller.rb
+++ b/app/controllers/api/v1/submissions_controller.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class SubmissionsController < Api::BaseController
+      include ApiOrganizationScoped
+
+      before_action :set_submission, only: [:show, :update, :destroy, :complete, :validate, :download]
+
+      # GET /api/v1/submissions
+      def index
+        submissions = current_organization.submissions.recent_first
+        render json: submissions.as_json
+      end
+
+      # GET /api/v1/submissions/:id
+      def show
+        render json: serialize_submission(@submission)
+      end
+
+      # POST /api/v1/submissions
+      def create
+        submission = current_organization.submissions.build(submission_params)
+
+        if submission.save
+          render json: submission.as_json, status: :created
+        else
+          render json: { errors: submission.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/submissions/:id
+      def update
+        if @submission.update(submission_params)
+          render json: @submission.as_json
+        else
+          render json: { errors: @submission.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/submissions/:id
+      def destroy
+        @submission.destroy
+        head :no_content
+      end
+
+      # POST /api/v1/submissions/:id/complete
+      def complete
+        result = Submissions::Complete.call(submission: @submission)
+
+        if result.success?
+          render json: serialize_submission(result.record)
+        else
+          render json: { errors: result.errors }, status: :unprocessable_entity
+        end
+      end
+
+      # POST /api/v1/submissions/:id/validate
+      def validate
+        result = Submissions::Validate.call(submission: @submission)
+        render json: result.record || { valid: result.success?, errors: result.errors }
+      end
+
+      # GET /api/v1/submissions/:id/download
+      def download
+        survey = Survey.new(organization: current_organization, year: @submission.year)
+        xml_content = survey.to_xbrl
+        send_data xml_content, filename: "amsf_survey_#{@submission.year}.xml", type: "application/xml"
+      end
+
+      # GET /api/v1/submissions/preview?year=2025
+      def preview
+        year = params[:year]&.to_i || Date.current.year
+        result = Submissions::Generate.call(organization: current_organization, year: year)
+
+        if result.success?
+          render json: result.record
+        else
+          render json: { errors: result.errors }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def set_submission
+        @submission = current_organization.submissions.find_by(id: params[:id])
+        render json: { error: "Submission not found" }, status: :not_found unless @submission
+      end
+
+      def submission_params
+        params.require(:submission).permit(:year, :taxonomy_version)
+      end
+
+      def serialize_submission(submission)
+        submission.as_json.merge(
+          "editable" => submission.editable?,
+          "merged_answers" => submission.merged_answers
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/trainings_controller.rb
+++ b/app/controllers/api/v1/trainings_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class TrainingsController < Api::BaseController
+      include ApiOrganizationScoped
+
+      before_action :set_training, only: [:show, :update, :destroy]
+
+      # GET /api/v1/trainings
+      def index
+        trainings = policy_scope(Training)
+        trainings = trainings.by_type(params[:training_type]) if params[:training_type].present?
+        trainings = trainings.for_year(params[:year].to_i) if params[:year].present?
+        trainings = trainings.recent
+
+        render json: trainings.as_json
+      end
+
+      # GET /api/v1/trainings/:id
+      def show
+        authorize @training
+        render json: @training.as_json
+      end
+
+      # POST /api/v1/trainings
+      def create
+        training = current_organization.trainings.build(training_params)
+        authorize training
+
+        if training.save
+          render json: training.as_json, status: :created
+        else
+          render json: { errors: training.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/trainings/:id
+      def update
+        authorize @training
+
+        if @training.update(training_params)
+          render json: @training.as_json
+        else
+          render json: { errors: @training.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/trainings/:id
+      def destroy
+        authorize @training
+        @training.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_training
+        @training = policy_scope(Training).find_by(id: params[:id])
+        render json: { error: "Training not found" }, status: :not_found unless @training
+      end
+
+      def training_params
+        params.require(:training).permit(
+          TrainingPolicy.new(pundit_user, Training).permitted_attributes
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class TransactionsController < Api::BaseController
+      include ApiOrganizationScoped
+
+      before_action :set_transaction, only: [:show, :update, :destroy, :screen]
+
+      # GET /api/v1/transactions
+      def index
+        transactions = policy_scope(Transaction).includes(:client)
+        transactions = transactions.where(transaction_type: params[:transaction_type]) if params[:transaction_type].present?
+        transactions = transactions.for_year(params[:year].to_i) if params[:year].present?
+        transactions = transactions.by_payment_method(params[:payment_method]) if params[:payment_method].present?
+        transactions = transactions.search(params[:q]) if params[:q].present?
+        transactions = transactions.recent
+
+        render json: transactions.as_json(include: { client: { only: [:id, :name] } })
+      end
+
+      # GET /api/v1/transactions/:id
+      def show
+        authorize @transaction
+        render json: @transaction.as_json(include: { client: { only: [:id, :name] } })
+      end
+
+      # POST /api/v1/transactions
+      def create
+        transaction = current_organization.transactions.build(transaction_params)
+        authorize transaction
+
+        if transaction.save
+          render json: transaction.as_json, status: :created
+        else
+          render json: { errors: transaction.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH /api/v1/transactions/:id
+      def update
+        authorize @transaction
+
+        if @transaction.update(transaction_params)
+          render json: @transaction.as_json
+        else
+          render json: { errors: @transaction.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      # DELETE /api/v1/transactions/:id
+      def destroy
+        authorize @transaction
+        @transaction.discard
+        head :no_content
+      end
+
+      # GET /api/v1/transactions/:id/screen
+      def screen
+        authorize @transaction, :show?
+
+        result = Transactions::Screen.call(transaction: @transaction)
+        render json: result.record
+      end
+
+      private
+
+      def set_transaction
+        @transaction = policy_scope(Transaction.with_discarded).find_by(id: params[:id])
+        render json: { error: "Transaction not found" }, status: :not_found unless @transaction
+      end
+
+      def transaction_params
+        params.require(:transaction).permit(
+          TransactionPolicy.new(pundit_user, Transaction).permitted_attributes
+        )
+      end
+    end
+  end
+end

--- a/app/services/clients/assess_risk.rb
+++ b/app/services/clients/assess_risk.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Clients
+  # Assesses a client's risk factors and returns a structured risk assessment.
+  # Does NOT auto-update the client's risk_level -- that requires human sign-off.
+  #
+  # Usage:
+  #   assessment = Clients::AssessRisk.call(client: client)
+  #   assessment.record  # => { suggested_level: "HIGH", factors: [...], current_level: "LOW" }
+  #
+  class AssessRisk
+    RISK_FACTORS = {
+      pep: { weight: :high, description: "Client is a Politically Exposed Person" },
+      pep_related: { weight: :high, description: "Client is related to a PEP" },
+      pep_associated: { weight: :high, description: "Client is associated with a PEP" },
+      vasp: { weight: :high, description: "Client is a Virtual Asset Service Provider" },
+      high_risk_country: { weight: :high, description: "Client from high-risk jurisdiction" },
+      non_resident: { weight: :medium, description: "Client is a non-resident" },
+      complex_structure: { weight: :medium, description: "Trust or complex legal structure" },
+      cash_transactions: { weight: :medium, description: "Client has cash transactions" },
+      beneficial_owner_pep: { weight: :high, description: "Beneficial owner is a PEP" },
+      str_filed: { weight: :high, description: "Suspicious transaction report filed" }
+    }.freeze
+
+    # FATF high-risk jurisdictions (simplified - should be configurable)
+    HIGH_RISK_COUNTRIES = %w[AF KP IR MM SY YE].freeze
+
+    def self.call(client:)
+      new(client: client).call
+    end
+
+    def initialize(client:)
+      @client = client
+    end
+
+    def call
+      factors = detect_factors
+      suggested_level = calculate_level(factors)
+
+      assessment = {
+        client_id: @client.id,
+        current_level: @client.risk_level,
+        suggested_level: suggested_level,
+        factors: factors,
+        requires_change: @client.risk_level != suggested_level,
+        assessed_at: Time.current
+      }
+
+      ServiceResult.success(assessment)
+    end
+
+    private
+
+    def detect_factors
+      factors = []
+      factors << factor(:pep) if @client.is_pep?
+      factors << factor(:pep_related) if @client.is_pep_related?
+      factors << factor(:pep_associated) if @client.is_pep_associated?
+      factors << factor(:vasp) if @client.is_vasp?
+
+      if @client.nationality.present? && HIGH_RISK_COUNTRIES.include?(@client.nationality)
+        factors << factor(:high_risk_country)
+      end
+
+      factors << factor(:non_resident) if @client.residence_status == "NON_RESIDENT"
+      factors << factor(:complex_structure) if @client.trust?
+      factors << factor(:cash_transactions) if @client.transactions.with_cash.exists?
+      factors << factor(:beneficial_owner_pep) if @client.beneficial_owners.peps.exists?
+      factors << factor(:str_filed) if @client.str_reports.exists?
+
+      factors
+    end
+
+    def factor(key)
+      config = RISK_FACTORS[key]
+      { key: key, weight: config[:weight], description: config[:description] }
+    end
+
+    def calculate_level(factors)
+      return "HIGH" if factors.any? { |f| f[:weight] == :high }
+      return "MEDIUM" if factors.any? { |f| f[:weight] == :medium }
+      "LOW"
+    end
+  end
+end

--- a/app/services/clients/create.rb
+++ b/app/services/clients/create.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Clients
+  # Creates a client within an organization.
+  #
+  # Usage:
+  #   result = Clients::Create.call(organization: org, params: { name: "Dupont", client_type: "NATURAL_PERSON" })
+  #   result.success? # => true
+  #   result.record    # => #<Client ...>
+  #
+  class Create
+    def self.call(organization:, params:)
+      client = organization.clients.build(params)
+
+      if client.save
+        ServiceResult.success(client)
+      else
+        ServiceResult.from_record(client)
+      end
+    end
+  end
+end

--- a/app/services/clients/onboard.rb
+++ b/app/services/clients/onboard.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Clients
+  # Onboards a client with optional beneficial owners in a single transaction.
+  # This is the primary entry point for AI agents creating clients with full KYC data.
+  #
+  # Usage:
+  #   result = Clients::Onboard.call(
+  #     organization: org,
+  #     client_params: { name: "Dupont SA", client_type: "LEGAL_ENTITY", legal_person_type: "SARL" },
+  #     beneficial_owners: [
+  #       { name: "Jean Dupont", ownership_percentage: 60, control_type: "DIRECT" },
+  #       { name: "Marie Dupont", ownership_percentage: 40, control_type: "DIRECT" }
+  #     ]
+  #   )
+  #
+  class Onboard
+    def self.call(organization:, client_params:, beneficial_owners: [])
+      new(organization: organization, client_params: client_params, beneficial_owners: beneficial_owners).call
+    end
+
+    def initialize(organization:, client_params:, beneficial_owners:)
+      @organization = organization
+      @client_params = client_params
+      @beneficial_owners = beneficial_owners
+    end
+
+    def call
+      client = nil
+
+      ActiveRecord::Base.transaction do
+        client = @organization.clients.build(@client_params)
+
+        unless client.save
+          return ServiceResult.from_record(client)
+        end
+
+        if @beneficial_owners.any? && !client.can_have_beneficial_owners?
+          client.errors.add(:base, "Natural persons cannot have beneficial owners")
+          raise ActiveRecord::Rollback
+        end
+
+        @beneficial_owners.each do |owner_params|
+          owner = client.beneficial_owners.build(owner_params)
+          unless owner.save
+            owner.errors.full_messages.each { |msg| client.errors.add(:beneficial_owners, msg) }
+            raise ActiveRecord::Rollback
+          end
+        end
+      end
+
+      if client.errors.any?
+        ServiceResult.failure(record: client, errors: client.errors.full_messages)
+      else
+        ServiceResult.success(client.reload)
+      end
+    end
+  end
+end

--- a/app/services/clients/update.rb
+++ b/app/services/clients/update.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Clients
+  # Updates an existing client.
+  #
+  # Usage:
+  #   result = Clients::Update.call(client: client, params: { name: "New Name" })
+  #
+  class Update
+    def self.call(client:, params:)
+      if client.update(params)
+        ServiceResult.success(client)
+      else
+        ServiceResult.from_record(client)
+      end
+    end
+  end
+end

--- a/app/services/compliance/gaps.rb
+++ b/app/services/compliance/gaps.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Compliance
+  # Identifies compliance gaps in an organization's data.
+  # Returns actionable items that need attention.
+  #
+  # Usage:
+  #   result = Compliance::Gaps.call(organization: org)
+  #   result.record  # => { gaps: [...], summary: { critical: 2, warning: 3 } }
+  #
+  class Gaps
+    def self.call(organization:, year: Date.current.year)
+      new(organization: organization, year: year).call
+    end
+
+    def initialize(organization:, year:)
+      @organization = organization
+      @year = year
+    end
+
+    def call
+      gaps = []
+
+      gaps.concat(client_gaps)
+      gaps.concat(beneficial_owner_gaps)
+      gaps.concat(training_gaps)
+      gaps.concat(submission_gaps)
+      gaps.concat(settings_gaps)
+
+      summary = {
+        total: gaps.size,
+        critical: gaps.count { |g| g[:severity] == :critical },
+        warning: gaps.count { |g| g[:severity] == :warning },
+        info: gaps.count { |g| g[:severity] == :info }
+      }
+
+      ServiceResult.success({ gaps: gaps, summary: summary })
+    end
+
+    private
+
+    def clients
+      @clients ||= @organization.clients.kept
+    end
+
+    def client_gaps
+      gaps = []
+
+      # Clients without risk assessment
+      unassessed = clients.where(risk_level: [nil, ""])
+      if unassessed.any?
+        gaps << {
+          severity: :critical,
+          category: :clients,
+          description: "#{unassessed.count} client(s) without risk assessment",
+          client_ids: unassessed.pluck(:id)
+        }
+      end
+
+      # Clients without due diligence level
+      no_dd = clients.where(due_diligence_level: [nil, ""])
+      if no_dd.any?
+        gaps << {
+          severity: :warning,
+          category: :clients,
+          description: "#{no_dd.count} client(s) without due diligence level set",
+          client_ids: no_dd.pluck(:id)
+        }
+      end
+
+      # PEP clients without enhanced due diligence
+      pep_without_edd = clients.peps.where.not(due_diligence_level: "REINFORCED")
+      if pep_without_edd.any?
+        gaps << {
+          severity: :critical,
+          category: :clients,
+          description: "#{pep_without_edd.count} PEP client(s) without reinforced due diligence",
+          client_ids: pep_without_edd.pluck(:id)
+        }
+      end
+
+      gaps
+    end
+
+    def beneficial_owner_gaps
+      gaps = []
+
+      # Legal entities/trusts without beneficial owners
+      entities_without_owners = clients
+        .where(client_type: %w[LEGAL_ENTITY TRUST])
+        .left_joins(:beneficial_owners)
+        .where(beneficial_owners: { id: nil })
+
+      if entities_without_owners.any?
+        gaps << {
+          severity: :critical,
+          category: :beneficial_owners,
+          description: "#{entities_without_owners.count} legal entity/trust client(s) without beneficial owners",
+          client_ids: entities_without_owners.pluck(:id)
+        }
+      end
+
+      gaps
+    end
+
+    def training_gaps
+      gaps = []
+
+      trainings_this_year = @organization.trainings.for_year(@year)
+      if trainings_this_year.empty?
+        gaps << {
+          severity: :warning,
+          category: :training,
+          description: "No staff training recorded for #{@year}"
+        }
+      end
+
+      gaps
+    end
+
+    def submission_gaps
+      gaps = []
+
+      submission = @organization.submissions.for_year(@year).first
+      if submission.nil?
+        gaps << {
+          severity: :info,
+          category: :submissions,
+          description: "No AMSF submission created for #{@year}"
+        }
+      elsif submission.draft?
+        gaps << {
+          severity: :warning,
+          category: :submissions,
+          description: "AMSF submission for #{@year} is still in draft status",
+          submission_id: submission.id
+        }
+      end
+
+      gaps
+    end
+
+    def settings_gaps
+      gaps = []
+
+      required_keys = %w[legal_form staff_total written_aml_policy]
+      existing_keys = @organization.settings.where(key: required_keys).pluck(:key)
+      missing = required_keys - existing_keys
+
+      if missing.any?
+        gaps << {
+          severity: :warning,
+          category: :settings,
+          description: "Missing required organization settings: #{missing.join(', ')}"
+        }
+      end
+
+      gaps
+    end
+  end
+end

--- a/app/services/compliance/risk_assessment.rb
+++ b/app/services/compliance/risk_assessment.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Compliance
+  # Generates an organization-wide risk assessment summary.
+  # Aggregates client risk data for compliance reporting.
+  #
+  # Usage:
+  #   result = Compliance::RiskAssessment.call(organization: org, year: 2025)
+  #   result.record  # => { clients: { total: 100, high: 5, ... }, transactions: {...} }
+  #
+  class RiskAssessment
+    def self.call(organization:, year: Date.current.year)
+      new(organization: organization, year: year).call
+    end
+
+    def initialize(organization:, year:)
+      @organization = organization
+      @year = year
+    end
+
+    def call
+      data = {
+        organization_id: @organization.id,
+        year: @year,
+        assessed_at: Time.current,
+        clients: client_summary,
+        transactions: transaction_summary,
+        str_reports: str_summary,
+        beneficial_owners: beneficial_owner_summary
+      }
+
+      ServiceResult.success(data)
+    end
+
+    private
+
+    def clients
+      @clients ||= @organization.clients.kept
+    end
+
+    def client_summary
+      {
+        total: clients.count,
+        by_risk_level: {
+          high: clients.high_risk.count,
+          medium: clients.where(risk_level: "MEDIUM").count,
+          low: clients.where(risk_level: "LOW").count,
+          unassessed: clients.where(risk_level: [nil, ""]).count
+        },
+        by_type: {
+          natural_persons: clients.natural_persons.count,
+          legal_entities: clients.legal_entities.count,
+          trusts: clients.trusts.count
+        },
+        peps: clients.peps.count,
+        vasps: clients.vasps.count,
+        non_residents: clients.non_residents.count,
+        active: clients.active.count,
+        ended: clients.ended.count
+      }
+    end
+
+    def transaction_summary
+      txns = @organization.transactions.kept.for_year(@year)
+      {
+        total: txns.count,
+        by_type: {
+          purchases: txns.purchases.count,
+          sales: txns.sales.count,
+          rentals: txns.rentals.count
+        },
+        with_cash: txns.with_cash.count,
+        total_value: txns.sum(:transaction_value),
+        total_cash: txns.sum(:cash_amount)
+      }
+    end
+
+    def str_summary
+      strs = @organization.str_reports.kept.for_year(@year)
+      {
+        total: strs.count,
+        by_reason: {
+          cash: strs.by_reason("CASH").count,
+          pep: strs.by_reason("PEP").count,
+          unusual_pattern: strs.by_reason("UNUSUAL_PATTERN").count,
+          other: strs.by_reason("OTHER").count
+        }
+      }
+    end
+
+    def beneficial_owner_summary
+      owners = BeneficialOwner.joins(:client).where(clients: { organization_id: @organization.id })
+      {
+        total: owners.count,
+        peps: owners.peps.count,
+        hnwis: owners.hnwis.count,
+        uhnwis: owners.uhnwis.count
+      }
+    end
+  end
+end

--- a/app/services/service_result.rb
+++ b/app/services/service_result.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Lightweight result object for service operations.
+# Avoids exceptions for expected failure paths (validation errors, business rule violations).
+#
+# Usage:
+#   result = ServiceResult.success(client)
+#   result.success?  # => true
+#   result.record     # => #<Client ...>
+#
+#   result = ServiceResult.failure(errors: ["Name can't be blank"])
+#   result.failure?  # => true
+#   result.errors    # => ["Name can't be blank"]
+#
+class ServiceResult
+  attr_reader :record, :errors
+
+  def initialize(success:, record: nil, errors: [])
+    @success = success
+    @record = record
+    @errors = Array(errors)
+  end
+
+  def success?
+    @success
+  end
+
+  def failure?
+    !@success
+  end
+
+  def self.success(record = nil)
+    new(success: true, record: record)
+  end
+
+  def self.failure(record: nil, errors: [])
+    new(success: false, record: record, errors: Array(errors))
+  end
+
+  # Build a failure result from an ActiveRecord model's errors
+  def self.from_record(record)
+    if record.errors.any?
+      failure(record: record, errors: record.errors.full_messages)
+    else
+      success(record)
+    end
+  end
+end

--- a/app/services/submissions/complete.rb
+++ b/app/services/submissions/complete.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Submissions
+  # Validates and completes a draft submission.
+  #
+  # Usage:
+  #   result = Submissions::Complete.call(submission: submission)
+  #   result.success?  # => true if validated + completed
+  #
+  class Complete
+    def self.call(submission:)
+      new(submission: submission).call
+    end
+
+    def initialize(submission:)
+      @submission = submission
+    end
+
+    def call
+      unless @submission.draft?
+        return ServiceResult.failure(
+          record: @submission,
+          errors: ["Submission is already completed"]
+        )
+      end
+
+      unless @submission.validate_xbrl
+        return ServiceResult.failure(
+          record: @submission,
+          errors: @submission.errors[:xbrl].presence || ["XBRL validation failed"]
+        )
+      end
+
+      @submission.complete!
+      ServiceResult.success(@submission)
+    rescue Submission::InvalidTransition => e
+      ServiceResult.failure(record: @submission, errors: [e.message])
+    end
+  end
+end

--- a/app/services/submissions/generate.rb
+++ b/app/services/submissions/generate.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Submissions
+  # Generates a survey preview for a submission year.
+  # Returns all calculated field values without creating XBRL.
+  #
+  # Usage:
+  #   result = Submissions::Generate.call(organization: org, year: 2025)
+  #   result.record  # => { fields: { "a1101" => 42, ... }, completion: 95.5, valid: true }
+  #
+  class Generate
+    def self.call(organization:, year:)
+      new(organization: organization, year: year).call
+    end
+
+    def initialize(organization:, year:)
+      @organization = organization
+      @year = year
+    end
+
+    def call
+      survey = Survey.new(organization: @organization, year: @year)
+
+      data = {
+        organization_id: @organization.id,
+        year: @year,
+        fields: survey.to_hash,
+        completion_percentage: survey.completion_percentage,
+        unanswered_questions: survey.unanswered_questions.map(&:id),
+        valid: survey.valid?
+      }
+
+      ServiceResult.success(data)
+    rescue => e
+      ServiceResult.failure(errors: [e.message])
+    end
+  end
+end

--- a/app/services/submissions/validate.rb
+++ b/app/services/submissions/validate.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Submissions
+  # Validates a submission's XBRL output (if Arelle is enabled).
+  #
+  # Usage:
+  #   result = Submissions::Validate.call(submission: submission)
+  #   result.success?  # => true/false
+  #   result.record    # => { valid: true/false, errors: [...] }
+  #
+  class Validate
+    def self.call(submission:)
+      new(submission: submission).call
+    end
+
+    def initialize(submission:)
+      @submission = submission
+    end
+
+    def call
+      valid = @submission.validate_xbrl
+
+      data = {
+        submission_id: @submission.id,
+        year: @submission.year,
+        valid: valid,
+        errors: @submission.errors[:xbrl]
+      }
+
+      if valid
+        ServiceResult.success(data)
+      else
+        ServiceResult.failure(errors: @submission.errors[:xbrl])
+      end
+    end
+  end
+end

--- a/app/services/transactions/screen.rb
+++ b/app/services/transactions/screen.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Transactions
+  # Screens a transaction against AML red flags.
+  # Returns risk indicators without blocking the transaction.
+  #
+  # Usage:
+  #   result = Transactions::Screen.call(transaction: txn)
+  #   result.record  # => { flags: [...], risk_score: "HIGH", recommend_str: true }
+  #
+  class Screen
+    # Screening thresholds
+    CASH_THRESHOLD = 10_000 # EUR - FATF threshold
+    HIGH_VALUE_THRESHOLD = 1_000_000 # EUR
+
+    def self.call(transaction:)
+      new(transaction: transaction).call
+    end
+
+    def initialize(transaction:)
+      @transaction = transaction
+    end
+
+    def call
+      flags = detect_flags
+      risk_score = calculate_risk(flags)
+
+      screening = {
+        transaction_id: @transaction.id,
+        flags: flags,
+        risk_score: risk_score,
+        recommend_str: risk_score == "HIGH",
+        screened_at: Time.current
+      }
+
+      ServiceResult.success(screening)
+    end
+
+    private
+
+    def detect_flags
+      flags = []
+      flags << cash_flag if cash_above_threshold?
+      flags << high_value_flag if high_value?
+      flags << pep_flag if client_is_pep?
+      flags << crypto_flag if crypto_payment?
+      flags << high_risk_client_flag if high_risk_client?
+      flags
+    end
+
+    def cash_above_threshold?
+      @transaction.cash_amount.present? && @transaction.cash_amount >= CASH_THRESHOLD
+    end
+
+    def high_value?
+      @transaction.transaction_value.present? && @transaction.transaction_value >= HIGH_VALUE_THRESHOLD
+    end
+
+    def client_is_pep?
+      @transaction.client&.is_pep?
+    end
+
+    def crypto_payment?
+      @transaction.payment_method == "CRYPTO"
+    end
+
+    def high_risk_client?
+      @transaction.client&.risk_level == "HIGH"
+    end
+
+    def cash_flag
+      { key: :cash_threshold, severity: :high,
+        description: "Cash amount (#{@transaction.cash_amount} EUR) exceeds #{CASH_THRESHOLD} EUR threshold" }
+    end
+
+    def high_value_flag
+      { key: :high_value, severity: :medium,
+        description: "Transaction value (#{@transaction.transaction_value} EUR) exceeds #{HIGH_VALUE_THRESHOLD} EUR" }
+    end
+
+    def pep_flag
+      { key: :pep_involved, severity: :high,
+        description: "Client is a Politically Exposed Person (#{@transaction.client.pep_type})" }
+    end
+
+    def crypto_flag
+      { key: :crypto_payment, severity: :medium,
+        description: "Transaction uses cryptocurrency payment" }
+    end
+
+    def high_risk_client_flag
+      { key: :high_risk_client, severity: :high,
+        description: "Client is classified as high risk" }
+    end
+
+    def calculate_risk(flags)
+      return "HIGH" if flags.any? { |f| f[:severity] == :high }
+      return "MEDIUM" if flags.any? { |f| f[:severity] == :medium }
+      "LOW"
+    end
+  end
+end

--- a/bin/immo
+++ b/bin/immo
@@ -1,0 +1,182 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Immo CRM CLI - Command-line interface for AI agents and power users.
+#
+# Usage:
+#   immo login --url https://app.immo.lu --token <api-token>
+#   immo clients list --risk_level HIGH
+#   immo compliance gaps --year 2025
+#   immo submissions preview --year 2025
+#
+# Add --format json for machine-readable output (default for piped output).
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require "cli/api_client"
+require "cli/config"
+require "cli/formatter"
+require "cli/commands"
+
+module Immo
+  module_function
+
+  def run(args)
+    format = extract_format(args)
+    formatter = Cli::Formatter.new(format: format)
+
+    case args.first
+    when "login"
+      args.shift
+      login(args, formatter)
+    when "logout"
+      Cli::Config.clear
+      formatter.success("Logged out. Config removed.")
+    when "status"
+      status(formatter)
+    when "help", nil, "-h", "--help"
+      print_usage
+    when "version", "--version"
+      puts "immo 0.1.0"
+    else
+      run_command(args, formatter)
+    end
+  rescue Cli::ApiClient::ApiError => e
+    formatter.error("API error (#{e.status}): #{e.body}")
+    exit 1
+  rescue => e
+    formatter.error(e.message)
+    exit 1
+  end
+
+  def extract_format(args)
+    idx = args.index("--format")
+    if idx
+      args.delete_at(idx)
+      format = args.delete_at(idx)
+      format&.to_sym || :table
+    elsif !$stdout.tty?
+      :json # Default to JSON when piped
+    else
+      :table
+    end
+  end
+
+  def login(args, formatter)
+    flags = {}
+    args.each_slice(2) do |key, value|
+      flags[key.sub(/^--/, "")] = value if key&.start_with?("--")
+    end
+
+    url = flags["url"] || ENV["IMMO_URL"]
+    token = flags["token"] || ENV["IMMO_TOKEN"]
+
+    unless url && token
+      formatter.error("Usage: immo login --url <url> --token <token>")
+      formatter.error("Or set IMMO_URL and IMMO_TOKEN environment variables")
+      exit 1
+    end
+
+    Cli::Config.set("url", url)
+    Cli::Config.set("token", token)
+    formatter.success("Logged in to #{url}")
+  end
+
+  def status(formatter)
+    config = Cli::Config.load
+    if Cli::Config.configured?
+      formatter.render({
+        "url" => config["url"],
+        "token" => "#{config['token'][0..7]}...",
+        "status" => "configured"
+      })
+    else
+      formatter.error("Not configured. Run: immo login --url <url> --token <token>")
+    end
+  end
+
+  def run_command(args, formatter)
+    unless Cli::Config.configured?
+      url = ENV["IMMO_URL"]
+      token = ENV["IMMO_TOKEN"]
+
+      unless url && token
+        formatter.error("Not configured. Run: immo login --url <url> --token <token>")
+        exit 1
+      end
+    end
+
+    config = Cli::Config.load
+    api_url = ENV["IMMO_URL"] || config["url"]
+    api_token = ENV["IMMO_TOKEN"] || config["token"]
+
+    client = Cli::ApiClient.new(base_url: api_url, token: api_token)
+    Cli::Commands.run(args, client: client, formatter: formatter)
+  end
+
+  def print_usage
+    puts <<~USAGE
+      Immo CRM CLI - AML/KYC compliance management
+
+      Usage: immo <command> [options]
+
+      Setup:
+        login                     Configure API credentials
+        logout                    Remove stored credentials
+        status                    Show current configuration
+
+      Resources:
+        clients list              List clients (--risk_level, --client_type, --q)
+        clients show <id>         Show client details
+        clients create <json>     Create a client
+        clients onboard <json>    Create client with beneficial owners
+        clients assess-risk <id>  Assess client risk factors
+        clients update <id> <json> Update a client
+        clients delete <id>       Soft-delete a client
+
+        transactions list         List transactions (--year, --payment_method, --transaction_type)
+        transactions show <id>    Show transaction details
+        transactions create <json> Create a transaction
+        transactions screen <id>  Screen transaction for AML flags
+        transactions delete <id>  Soft-delete a transaction
+
+        str-reports list          List STR reports (--year, --reason)
+        str-reports show <id>     Show STR report
+        str-reports create <json> Create an STR report
+
+        properties list           List managed properties (--status, --property_type)
+        properties show <id>      Show property details
+        properties create <json>  Create a property
+
+        trainings list            List trainings (--year, --training_type)
+        trainings show <id>       Show training details
+        trainings create <json>   Create a training record
+
+        submissions list          List AMSF submissions
+        submissions show <id>     Show submission details
+        submissions create <json> Create a submission
+        submissions preview       Preview survey calculations (--year)
+        submissions validate <id> Validate submission XBRL
+        submissions complete <id> Complete a draft submission
+        submissions download <id> Download XBRL file
+
+      Compliance:
+        compliance gaps           Show compliance gaps (--year)
+        compliance risk-assessment Organization risk summary (--year)
+
+      Options:
+        --format json             JSON output (default when piped)
+        --file <path>             Read input from JSON file
+        --help                    Show this help
+
+      Examples:
+        immo clients list --risk_level HIGH
+        immo clients create '{"name":"Dupont SA","client_type":"LEGAL_ENTITY","legal_person_type":"SARL"}'
+        immo clients onboard --file new_client.json
+        immo compliance gaps --year 2025
+        immo submissions preview --year 2025
+        immo transactions screen 42
+    USAGE
+  end
+end
+
+Immo.run(ARGV.dup)

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -6,6 +6,43 @@ namespace :api, defaults: {format: :json} do
     resources :accounts
     resources :users
     resources :notification_tokens, param: :token, only: [:create, :destroy]
+
+    # CRM resources
+    resources :clients do
+      collection do
+        post :onboard
+      end
+      member do
+        get :assess_risk
+      end
+      resources :beneficial_owners, only: [:index, :create]
+    end
+    resources :beneficial_owners, only: [:show, :update, :destroy]
+
+    resources :transactions do
+      member do
+        get :screen
+      end
+    end
+
+    resources :str_reports
+    resources :managed_properties
+    resources :trainings
+
+    resources :submissions do
+      member do
+        post :complete
+        post :validate
+        get :download
+      end
+      collection do
+        get :preview
+      end
+    end
+
+    # Compliance endpoints
+    get "compliance/gaps", to: "compliance#gaps"
+    get "compliance/risk_assessment", to: "compliance#risk_assessment"
   end
 end
 

--- a/lib/cli/api_client.rb
+++ b/lib/cli/api_client.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+require "uri"
+
+module Cli
+  # HTTP client for the Immo CRM API.
+  # Handles authentication, JSON serialization, and error handling.
+  class ApiClient
+    class ApiError < StandardError
+      attr_reader :status, :body
+
+      def initialize(status, body)
+        @status = status
+        @body = body
+        super("HTTP #{status}: #{body}")
+      end
+    end
+
+    def initialize(base_url:, token:)
+      @base_url = base_url.chomp("/")
+      @token = token
+    end
+
+    def get(path, params: {})
+      uri = build_uri(path, params)
+      request = Net::HTTP::Get.new(uri)
+      execute(uri, request)
+    end
+
+    def post(path, body: {})
+      uri = build_uri(path)
+      request = Net::HTTP::Post.new(uri)
+      request.body = body.to_json
+      execute(uri, request)
+    end
+
+    def patch(path, body: {})
+      uri = build_uri(path)
+      request = Net::HTTP::Patch.new(uri)
+      request.body = body.to_json
+      execute(uri, request)
+    end
+
+    def delete(path)
+      uri = build_uri(path)
+      request = Net::HTTP::Delete.new(uri)
+      execute(uri, request)
+    end
+
+    private
+
+    def build_uri(path, params = {})
+      uri = URI("#{@base_url}/api/v1#{path}")
+      uri.query = URI.encode_www_form(params) if params.any?
+      uri
+    end
+
+    def execute(uri, request)
+      request["Authorization"] = "token #{@token}"
+      request["Content-Type"] = "application/json"
+      request["Accept"] = "application/json"
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == "https")
+      http.open_timeout = 10
+      http.read_timeout = 30
+
+      response = http.request(request)
+
+      case response.code.to_i
+      when 200..299
+        return nil if response.body.nil? || response.body.empty?
+        JSON.parse(response.body)
+      else
+        raise ApiError.new(response.code.to_i, response.body)
+      end
+    end
+  end
+end

--- a/lib/cli/commands.rb
+++ b/lib/cli/commands.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+module Cli
+  # Command dispatcher for the Immo CLI.
+  # Routes subcommands to the appropriate API calls.
+  module Commands
+    module_function
+
+    def run(args, client:, formatter:)
+      resource = args.shift
+      action = args.shift
+
+      case resource
+      when "clients"    then clients(action, args, client: client, formatter: formatter)
+      when "transactions" then transactions(action, args, client: client, formatter: formatter)
+      when "str-reports"  then str_reports(action, args, client: client, formatter: formatter)
+      when "properties"   then properties(action, args, client: client, formatter: formatter)
+      when "trainings"    then trainings(action, args, client: client, formatter: formatter)
+      when "submissions"  then submissions(action, args, client: client, formatter: formatter)
+      when "compliance"   then compliance(action, args, client: client, formatter: formatter)
+      else
+        formatter.error("Unknown resource: #{resource}")
+        print_help(formatter)
+      end
+    end
+
+    def clients(action, args, client:, formatter:)
+      case action
+      when "list"
+        params = parse_flags(args)
+        data = client.get("/clients", params: params)
+        formatter.render(data, columns: %w[id name client_type risk_level is_pep created_at])
+
+      when "show"
+        id = args.shift
+        data = client.get("/clients/#{id}")
+        formatter.render(data)
+
+      when "create"
+        body = parse_json_arg(args)
+        data = client.post("/clients", body: { client: body })
+        formatter.success("Client created (id: #{data['id']})")
+        formatter.render(data)
+
+      when "onboard"
+        body = parse_json_arg(args)
+        data = client.post("/clients/onboard", body: body)
+        formatter.success("Client onboarded (id: #{data['id']})")
+        formatter.render(data)
+
+      when "assess-risk"
+        id = args.shift
+        data = client.get("/clients/#{id}/assess_risk")
+        formatter.render(data)
+
+      when "update"
+        id = args.shift
+        body = parse_json_arg(args)
+        data = client.patch("/clients/#{id}", body: { client: body })
+        formatter.success("Client updated")
+        formatter.render(data)
+
+      when "delete"
+        id = args.shift
+        client.delete("/clients/#{id}")
+        formatter.success("Client deleted")
+
+      else
+        formatter.error("Usage: immo clients [list|show|create|onboard|assess-risk|update|delete]")
+      end
+    end
+
+    def transactions(action, args, client:, formatter:)
+      case action
+      when "list"
+        params = parse_flags(args)
+        data = client.get("/transactions", params: params)
+        formatter.render(data, columns: %w[id transaction_type transaction_date payment_method transaction_value])
+
+      when "show"
+        id = args.shift
+        data = client.get("/transactions/#{id}")
+        formatter.render(data)
+
+      when "create"
+        body = parse_json_arg(args)
+        data = client.post("/transactions", body: { transaction: body })
+        formatter.success("Transaction created (id: #{data['id']})")
+
+      when "screen"
+        id = args.shift
+        data = client.get("/transactions/#{id}/screen")
+        formatter.render(data)
+
+      when "delete"
+        id = args.shift
+        client.delete("/transactions/#{id}")
+        formatter.success("Transaction deleted")
+
+      else
+        formatter.error("Usage: immo transactions [list|show|create|screen|delete]")
+      end
+    end
+
+    def str_reports(action, args, client:, formatter:)
+      case action
+      when "list"
+        params = parse_flags(args)
+        data = client.get("/str_reports", params: params)
+        formatter.render(data, columns: %w[id reason report_date notes])
+
+      when "show"
+        id = args.shift
+        data = client.get("/str_reports/#{id}")
+        formatter.render(data)
+
+      when "create"
+        body = parse_json_arg(args)
+        data = client.post("/str_reports", body: { str_report: body })
+        formatter.success("STR report created (id: #{data['id']})")
+
+      when "delete"
+        id = args.shift
+        client.delete("/str_reports/#{id}")
+        formatter.success("STR report deleted")
+
+      else
+        formatter.error("Usage: immo str-reports [list|show|create|delete]")
+      end
+    end
+
+    def properties(action, args, client:, formatter:)
+      case action
+      when "list"
+        params = parse_flags(args)
+        data = client.get("/managed_properties", params: params)
+        formatter.render(data, columns: %w[id property_address property_type management_start_date monthly_rent])
+
+      when "show"
+        id = args.shift
+        data = client.get("/managed_properties/#{id}")
+        formatter.render(data)
+
+      when "create"
+        body = parse_json_arg(args)
+        data = client.post("/managed_properties", body: { managed_property: body })
+        formatter.success("Property created (id: #{data['id']})")
+
+      when "delete"
+        id = args.shift
+        client.delete("/managed_properties/#{id}")
+        formatter.success("Property deleted")
+
+      else
+        formatter.error("Usage: immo properties [list|show|create|delete]")
+      end
+    end
+
+    def trainings(action, args, client:, formatter:)
+      case action
+      when "list"
+        params = parse_flags(args)
+        data = client.get("/trainings", params: params)
+        formatter.render(data, columns: %w[id training_date training_type topic staff_count])
+
+      when "show"
+        id = args.shift
+        data = client.get("/trainings/#{id}")
+        formatter.render(data)
+
+      when "create"
+        body = parse_json_arg(args)
+        data = client.post("/trainings", body: { training: body })
+        formatter.success("Training created (id: #{data['id']})")
+
+      when "delete"
+        id = args.shift
+        client.delete("/trainings/#{id}")
+        formatter.success("Training deleted")
+
+      else
+        formatter.error("Usage: immo trainings [list|show|create|delete]")
+      end
+    end
+
+    def submissions(action, args, client:, formatter:)
+      case action
+      when "list"
+        data = client.get("/submissions")
+        formatter.render(data, columns: %w[id year status taxonomy_version completed_at])
+
+      when "show"
+        id = args.shift
+        data = client.get("/submissions/#{id}")
+        formatter.render(data)
+
+      when "create"
+        body = parse_json_arg(args)
+        data = client.post("/submissions", body: { submission: body })
+        formatter.success("Submission created (id: #{data['id']})")
+
+      when "preview"
+        params = parse_flags(args)
+        data = client.get("/submissions/preview", params: params)
+        formatter.render(data)
+
+      when "validate"
+        id = args.shift
+        data = client.post("/submissions/#{id}/validate")
+        formatter.render(data)
+
+      when "complete"
+        id = args.shift
+        data = client.post("/submissions/#{id}/complete")
+        formatter.success("Submission completed")
+        formatter.render(data)
+
+      when "download"
+        id = args.shift
+        data = client.get("/submissions/#{id}/download")
+        # If raw XML, write to file
+        filename = "amsf_submission_#{id}.xml"
+        File.write(filename, data.is_a?(String) ? data : data.to_json)
+        formatter.success("Downloaded to #{filename}")
+
+      else
+        formatter.error("Usage: immo submissions [list|show|create|preview|validate|complete|download]")
+      end
+    end
+
+    def compliance(action, args, client:, formatter:)
+      case action
+      when "gaps"
+        params = parse_flags(args)
+        data = client.get("/compliance/gaps", params: params)
+        formatter.render(data)
+
+      when "risk-assessment"
+        params = parse_flags(args)
+        data = client.get("/compliance/risk_assessment", params: params)
+        formatter.render(data)
+
+      else
+        formatter.error("Usage: immo compliance [gaps|risk-assessment]")
+      end
+    end
+
+    def parse_flags(args)
+      params = {}
+      args.each_slice(2) do |key, value|
+        next unless key&.start_with?("--")
+        params[key.sub(/^--/, "")] = value
+      end
+      params
+    end
+
+    def parse_json_arg(args)
+      # Accept --file path or inline JSON
+      if args.first == "--file"
+        args.shift
+        path = args.shift
+        JSON.parse(File.read(path))
+      elsif args.first&.start_with?("{")
+        JSON.parse(args.join(" "))
+      else
+        parse_flags(args)
+      end
+    end
+
+    def print_help(formatter)
+      formatter.render({
+        "resources" => %w[clients transactions str-reports properties trainings submissions compliance],
+        "examples" => [
+          "immo clients list --risk_level HIGH",
+          "immo clients create '{\"name\":\"Dupont\",\"client_type\":\"NATURAL_PERSON\"}'",
+          "immo clients onboard --file client.json",
+          "immo compliance gaps --year 2025",
+          "immo submissions preview --year 2025"
+        ]
+      })
+    end
+  end
+end

--- a/lib/cli/config.rb
+++ b/lib/cli/config.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+
+module Cli
+  # Manages CLI configuration (API URL, token) persisted to ~/.immo.json
+  class Config
+    CONFIG_PATH = File.expand_path("~/.immo.json")
+
+    def self.load
+      return {} unless File.exist?(CONFIG_PATH)
+      JSON.parse(File.read(CONFIG_PATH))
+    rescue JSON::ParserError
+      {}
+    end
+
+    def self.save(data)
+      FileUtils.mkdir_p(File.dirname(CONFIG_PATH))
+      File.write(CONFIG_PATH, JSON.pretty_generate(data))
+      File.chmod(0o600, CONFIG_PATH) # Restrict permissions
+    end
+
+    def self.get(key)
+      load[key]
+    end
+
+    def self.set(key, value)
+      config = load
+      config[key] = value
+      save(config)
+    end
+
+    def self.configured?
+      config = load
+      config["url"].to_s.length > 0 && config["token"].to_s.length > 0
+    end
+
+    def self.clear
+      File.delete(CONFIG_PATH) if File.exist?(CONFIG_PATH)
+    end
+  end
+end

--- a/lib/cli/formatter.rb
+++ b/lib/cli/formatter.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Cli
+  # Formats API responses for terminal output.
+  # Supports both human-readable tables and JSON output for agents.
+  class Formatter
+    def initialize(format: :table)
+      @format = format
+    end
+
+    def render(data, columns: nil)
+      if @format == :json
+        puts JSON.pretty_generate(data)
+        return
+      end
+
+      case data
+      when Array
+        render_table(data, columns: columns)
+      when Hash
+        render_hash(data)
+      else
+        puts data
+      end
+    end
+
+    def success(message)
+      if @format == :json
+        puts JSON.generate({ status: "ok", message: message })
+      else
+        puts "\e[32m#{message}\e[0m" # Green
+      end
+    end
+
+    def error(message)
+      if @format == :json
+        puts JSON.generate({ status: "error", message: message })
+      else
+        $stderr.puts "\e[31mError: #{message}\e[0m" # Red
+      end
+    end
+
+    private
+
+    def render_table(rows, columns: nil)
+      return puts "No results." if rows.empty?
+
+      columns ||= rows.first.keys
+      columns = columns.map(&:to_s)
+
+      # Calculate column widths
+      widths = columns.map { |col| col.length }
+      rows.each do |row|
+        columns.each_with_index do |col, i|
+          val = row[col].to_s
+          widths[i] = [widths[i], val.length].max
+        end
+      end
+
+      # Cap column widths
+      widths = widths.map { |w| [w, 40].min }
+
+      # Header
+      header = columns.each_with_index.map { |col, i| col.upcase.ljust(widths[i]) }.join("  ")
+      puts header
+      puts "-" * header.length
+
+      # Rows
+      rows.each do |row|
+        line = columns.each_with_index.map do |col, i|
+          row[col].to_s.ljust(widths[i])[0...widths[i]]
+        end.join("  ")
+        puts line
+      end
+
+      puts "\n#{rows.size} result(s)"
+    end
+
+    def render_hash(hash, indent: 0)
+      hash.each do |key, value|
+        prefix = "  " * indent
+        case value
+        when Hash
+          puts "#{prefix}#{key}:"
+          render_hash(value, indent: indent + 1)
+        when Array
+          if value.first.is_a?(Hash)
+            puts "#{prefix}#{key}:"
+            value.each_with_index do |item, idx|
+              puts "#{prefix}  [#{idx}]"
+              render_hash(item, indent: indent + 2)
+            end
+          else
+            puts "#{prefix}#{key}: #{value.join(', ')}"
+          end
+        else
+          puts "#{prefix}#{key}: #{value}"
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/clients_controller_test.rb
+++ b/test/controllers/api/v1/clients_controller_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::ClientsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @account = accounts(:one)
+    @organization = organizations(:one)
+    @client = clients(:natural_person)
+    @token = api_tokens(:one).token
+    @headers = { "Authorization" => "token #{@token}", "Content-Type" => "application/json" }
+  end
+
+  # === Authentication ===
+
+  test "returns 401 without token" do
+    get api_v1_clients_path, as: :json
+    assert_response :unauthorized
+  end
+
+  # === Index ===
+
+  test "lists clients" do
+    get api_v1_clients_path, headers: @headers, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert_kind_of Array, data
+    assert data.any? { |c| c["id"] == @client.id }
+  end
+
+  test "filters clients by risk level" do
+    get api_v1_clients_path, headers: @headers, params: { risk_level: "HIGH" }, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert data.all? { |c| c["risk_level"] == "HIGH" }
+  end
+
+  test "filters clients by type" do
+    get api_v1_clients_path, headers: @headers, params: { client_type: "NATURAL_PERSON" }, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert data.all? { |c| c["client_type"] == "NATURAL_PERSON" }
+  end
+
+  # === Show ===
+
+  test "shows client details" do
+    get api_v1_client_path(@client), headers: @headers, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert_equal @client.name, data["name"]
+  end
+
+  test "returns 404 for client from other organization" do
+    other_client = clients(:other_org_client)
+    get api_v1_client_path(other_client), headers: @headers, as: :json
+    assert_response :not_found
+  end
+
+  # === Create ===
+
+  test "creates a client" do
+    assert_difference "Client.count", 1 do
+      post api_v1_clients_path, headers: @headers, params: {
+        client: { name: "API Client", client_type: "NATURAL_PERSON" }
+      }.to_json, as: :json
+    end
+
+    assert_response :created
+    data = JSON.parse(response.body)
+    assert_equal "API Client", data["name"]
+  end
+
+  test "returns errors for invalid client" do
+    post api_v1_clients_path, headers: @headers, params: {
+      client: { name: "", client_type: "NATURAL_PERSON" }
+    }.to_json, as: :json
+
+    assert_response :unprocessable_entity
+    data = JSON.parse(response.body)
+    assert data["errors"].any?
+  end
+
+  # === Onboard ===
+
+  test "onboards client with beneficial owners" do
+    assert_difference ["Client.count", "BeneficialOwner.count"], 1 do
+      post onboard_api_v1_clients_path, headers: @headers, params: {
+        client: { name: "Onboard Corp", client_type: "LEGAL_ENTITY", legal_person_type: "SA" },
+        beneficial_owners: [
+          { name: "Owner 1", ownership_percentage: 100, control_type: "DIRECT" }
+        ]
+      }.to_json, as: :json
+    end
+
+    assert_response :created
+    data = JSON.parse(response.body)
+    assert_equal "Onboard Corp", data["name"]
+    assert data["beneficial_owners"].any?
+  end
+
+  # === Update ===
+
+  test "updates a client" do
+    patch api_v1_client_path(@client), headers: @headers, params: {
+      client: { name: "Updated via API" }
+    }.to_json, as: :json
+
+    assert_response :success
+    @client.reload
+    assert_equal "Updated via API", @client.name
+  end
+
+  # === Delete ===
+
+  test "soft deletes a client" do
+    delete api_v1_client_path(@client), headers: @headers, as: :json
+    assert_response :no_content
+
+    @client.reload
+    assert @client.discarded?
+  end
+
+  # === Risk Assessment ===
+
+  test "returns risk assessment for client" do
+    get assess_risk_api_v1_client_path(@client), headers: @headers, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert data.key?("suggested_level")
+    assert data.key?("factors")
+  end
+end

--- a/test/controllers/api/v1/compliance_controller_test.rb
+++ b/test/controllers/api/v1/compliance_controller_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::ComplianceControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @organization = organizations(:one)
+    @token = api_tokens(:one).token
+    @headers = { "Authorization" => "token #{@token}", "Content-Type" => "application/json" }
+  end
+
+  test "returns compliance gaps" do
+    get api_v1_compliance_gaps_path, headers: @headers, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert data.key?("gaps")
+    assert data.key?("summary")
+  end
+
+  test "returns compliance gaps for specific year" do
+    get api_v1_compliance_gaps_path, headers: @headers, params: { year: 2024 }, as: :json
+    assert_response :success
+  end
+
+  test "returns risk assessment" do
+    get api_v1_compliance_risk_assessment_path, headers: @headers, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert data.key?("clients")
+    assert data.key?("transactions")
+    assert data.key?("str_reports")
+    assert data.key?("beneficial_owners")
+  end
+
+  test "returns risk assessment for specific year" do
+    get api_v1_compliance_risk_assessment_path, headers: @headers, params: { year: 2024 }, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert_equal 2024, data["year"]
+  end
+end

--- a/test/controllers/api/v1/submissions_controller_test.rb
+++ b/test/controllers/api/v1/submissions_controller_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::SubmissionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @organization = organizations(:one)
+    @token = api_tokens(:one).token
+    @headers = { "Authorization" => "token #{@token}", "Content-Type" => "application/json" }
+  end
+
+  test "lists submissions" do
+    get api_v1_submissions_path, headers: @headers, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert_kind_of Array, data
+  end
+
+  test "creates submission" do
+    # Use a unique year that doesn't conflict with fixtures
+    assert_difference "Submission.count", 1 do
+      post api_v1_submissions_path, headers: @headers, params: {
+        submission: { year: 2099 }
+      }.to_json, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "previews survey calculations" do
+    get preview_api_v1_submissions_path, headers: @headers, params: { year: 2025 }, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert data.key?("fields")
+    assert data.key?("completion_percentage")
+  end
+end

--- a/test/controllers/api/v1/transactions_controller_test.rb
+++ b/test/controllers/api/v1/transactions_controller_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::TransactionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @organization = organizations(:one)
+    @transaction = transactions(:purchase)
+    @client = clients(:natural_person)
+    @token = api_tokens(:one).token
+    @headers = { "Authorization" => "token #{@token}", "Content-Type" => "application/json" }
+  end
+
+  test "lists transactions" do
+    get api_v1_transactions_path, headers: @headers, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert_kind_of Array, data
+  end
+
+  test "shows transaction" do
+    get api_v1_transaction_path(@transaction), headers: @headers, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert_equal @transaction.reference, data["reference"]
+  end
+
+  test "creates transaction" do
+    assert_difference "Transaction.count", 1 do
+      post api_v1_transactions_path, headers: @headers, params: {
+        transaction: {
+          client_id: @client.id,
+          transaction_date: Date.current.to_s,
+          transaction_type: "PURCHASE",
+          payment_method: "WIRE",
+          transaction_value: 500000
+        }
+      }.to_json, as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "screens transaction for AML flags" do
+    get screen_api_v1_transaction_path(@transaction), headers: @headers, as: :json
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    assert data.key?("flags")
+    assert data.key?("risk_score")
+  end
+
+  test "soft deletes transaction" do
+    delete api_v1_transaction_path(@transaction), headers: @headers, as: :json
+    assert_response :no_content
+  end
+end

--- a/test/services/clients/assess_risk_test.rb
+++ b/test/services/clients/assess_risk_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Clients::AssessRiskTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:one)
+    @user = users(:one)
+    set_current_context(user: @user, organization: @organization)
+  end
+
+  test "low risk for clean client" do
+    client = clients(:natural_person)
+    result = Clients::AssessRisk.call(client: client)
+
+    assert result.success?
+    assert_equal "LOW", result.record[:suggested_level]
+    assert_empty result.record[:factors]
+  end
+
+  test "high risk for PEP client" do
+    client = clients(:pep_client)
+    result = Clients::AssessRisk.call(client: client)
+
+    assert result.success?
+    assert_equal "HIGH", result.record[:suggested_level]
+    assert result.record[:factors].any? { |f| f[:key] == :pep }
+  end
+
+  test "high risk for VASP client" do
+    client = clients(:vasp_client)
+    result = Clients::AssessRisk.call(client: client)
+
+    assert result.success?
+    assert_equal "HIGH", result.record[:suggested_level]
+    assert result.record[:factors].any? { |f| f[:key] == :vasp }
+  end
+
+  test "indicates when risk level change is needed" do
+    client = clients(:pep_client)
+    # PEP client is already HIGH, so no change needed
+    result = Clients::AssessRisk.call(client: client)
+
+    assert_not result.record[:requires_change]
+  end
+
+  test "flags when current level differs from suggested" do
+    # natural_person is LOW risk, no factors -> LOW suggested, no change
+    client = clients(:natural_person)
+    result = Clients::AssessRisk.call(client: client)
+
+    assert_not result.record[:requires_change]
+  end
+end

--- a/test/services/clients/create_test.rb
+++ b/test/services/clients/create_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Clients::CreateTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:one)
+    @user = users(:one)
+    set_current_context(user: @user, organization: @organization)
+  end
+
+  test "creates a valid client" do
+    result = Clients::Create.call(
+      organization: @organization,
+      params: { name: "New Client", client_type: "NATURAL_PERSON" }
+    )
+
+    assert result.success?
+    assert_equal "New Client", result.record.name
+    assert_equal @organization, result.record.organization
+  end
+
+  test "returns failure for invalid client" do
+    result = Clients::Create.call(
+      organization: @organization,
+      params: { name: "", client_type: "NATURAL_PERSON" }
+    )
+
+    assert result.failure?
+    assert result.errors.any? { |e| e.include?("Name") }
+  end
+
+  test "creates legal entity with legal_person_type" do
+    result = Clients::Create.call(
+      organization: @organization,
+      params: { name: "Corp", client_type: "LEGAL_ENTITY", legal_person_type: "SARL" }
+    )
+
+    assert result.success?
+    assert_equal "LEGAL_ENTITY", result.record.client_type
+    assert_equal "SARL", result.record.legal_person_type
+  end
+end

--- a/test/services/clients/onboard_test.rb
+++ b/test/services/clients/onboard_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Clients::OnboardTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:one)
+    @user = users(:one)
+    set_current_context(user: @user, organization: @organization)
+  end
+
+  test "onboards client without beneficial owners" do
+    result = Clients::Onboard.call(
+      organization: @organization,
+      client_params: { name: "Simple Client", client_type: "NATURAL_PERSON" }
+    )
+
+    assert result.success?
+    assert_equal "Simple Client", result.record.name
+  end
+
+  test "onboards legal entity with beneficial owners" do
+    result = Clients::Onboard.call(
+      organization: @organization,
+      client_params: { name: "Corp SA", client_type: "LEGAL_ENTITY", legal_person_type: "SA" },
+      beneficial_owners: [
+        { name: "Owner 1", ownership_percentage: 60, control_type: "DIRECT" },
+        { name: "Owner 2", ownership_percentage: 40, control_type: "DIRECT" }
+      ]
+    )
+
+    assert result.success?
+    assert_equal 2, result.record.beneficial_owners.count
+    assert_equal "Owner 1", result.record.beneficial_owners.first.name
+  end
+
+  test "rolls back when beneficial owner is invalid" do
+    initial_client_count = Client.count
+    initial_owner_count = BeneficialOwner.count
+
+    result = Clients::Onboard.call(
+      organization: @organization,
+      client_params: { name: "Corp", client_type: "LEGAL_ENTITY", legal_person_type: "SA" },
+      beneficial_owners: [
+        { name: "", ownership_percentage: 60 } # Invalid - missing name
+      ]
+    )
+
+    assert result.failure?
+    assert_equal initial_client_count, Client.count
+    assert_equal initial_owner_count, BeneficialOwner.count
+  end
+
+  test "rejects beneficial owners for natural person" do
+    result = Clients::Onboard.call(
+      organization: @organization,
+      client_params: { name: "Person", client_type: "NATURAL_PERSON" },
+      beneficial_owners: [
+        { name: "Owner", ownership_percentage: 100 }
+      ]
+    )
+
+    assert result.failure?
+    assert result.errors.any? { |e| e.include?("beneficial owners") }
+  end
+end

--- a/test/services/compliance/gaps_test.rb
+++ b/test/services/compliance/gaps_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Compliance::GapsTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:one)
+    @user = users(:one)
+    set_current_context(user: @user, organization: @organization)
+  end
+
+  test "returns gaps with summary" do
+    result = Compliance::Gaps.call(organization: @organization)
+
+    assert result.success?
+    assert result.record.key?(:gaps)
+    assert result.record.key?(:summary)
+    assert result.record[:summary].key?(:total)
+    assert result.record[:summary].key?(:critical)
+    assert result.record[:summary].key?(:warning)
+  end
+
+  test "detects missing settings" do
+    result = Compliance::Gaps.call(organization: @organization)
+
+    settings_gaps = result.record[:gaps].select { |g| g[:category] == :settings }
+    # Organization :one likely doesn't have all required settings
+    assert settings_gaps.any? || @organization.settings.where(key: %w[legal_form staff_total written_aml_policy]).count == 3
+  end
+
+  test "accepts year parameter" do
+    result = Compliance::Gaps.call(organization: @organization, year: 2024)
+
+    assert result.success?
+  end
+end

--- a/test/services/compliance/risk_assessment_test.rb
+++ b/test/services/compliance/risk_assessment_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Compliance::RiskAssessmentTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:one)
+    @user = users(:one)
+    set_current_context(user: @user, organization: @organization)
+  end
+
+  test "returns complete assessment structure" do
+    result = Compliance::RiskAssessment.call(organization: @organization)
+
+    assert result.success?
+    data = result.record
+    assert data.key?(:clients)
+    assert data.key?(:transactions)
+    assert data.key?(:str_reports)
+    assert data.key?(:beneficial_owners)
+    assert data.key?(:assessed_at)
+  end
+
+  test "client summary includes counts by risk level" do
+    result = Compliance::RiskAssessment.call(organization: @organization)
+
+    clients = result.record[:clients]
+    assert clients[:total] > 0
+    assert clients[:by_risk_level].key?(:high)
+    assert clients[:by_risk_level].key?(:medium)
+    assert clients[:by_risk_level].key?(:low)
+  end
+
+  test "client summary includes counts by type" do
+    result = Compliance::RiskAssessment.call(organization: @organization)
+
+    clients = result.record[:clients]
+    assert clients[:by_type].key?(:natural_persons)
+    assert clients[:by_type].key?(:legal_entities)
+    assert clients[:by_type].key?(:trusts)
+  end
+
+  test "accepts year parameter" do
+    result = Compliance::RiskAssessment.call(organization: @organization, year: 2024)
+
+    assert result.success?
+    assert_equal 2024, result.record[:year]
+  end
+end

--- a/test/services/service_result_test.rb
+++ b/test/services/service_result_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ServiceResultTest < ActiveSupport::TestCase
+  test "success result" do
+    result = ServiceResult.success("data")
+    assert result.success?
+    assert_not result.failure?
+    assert_equal "data", result.record
+    assert_empty result.errors
+  end
+
+  test "failure result with errors" do
+    result = ServiceResult.failure(errors: ["Something went wrong"])
+    assert result.failure?
+    assert_not result.success?
+    assert_equal ["Something went wrong"], result.errors
+  end
+
+  test "failure result with record" do
+    client = clients(:natural_person)
+    result = ServiceResult.failure(record: client, errors: ["Name can't be blank"])
+    assert result.failure?
+    assert_equal client, result.record
+  end
+
+  test "success with nil record" do
+    result = ServiceResult.success
+    assert result.success?
+    assert_nil result.record
+  end
+
+  test "from_record with valid record" do
+    client = clients(:natural_person)
+    result = ServiceResult.from_record(client)
+    assert result.success?
+    assert_equal client, result.record
+  end
+
+  test "from_record with invalid record" do
+    client = Client.new # Missing required fields
+    client.valid?
+    result = ServiceResult.from_record(client)
+    assert result.failure?
+    assert result.errors.any?
+  end
+end

--- a/test/services/transactions/screen_test.rb
+++ b/test/services/transactions/screen_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Transactions::ScreenTest < ActiveSupport::TestCase
+  setup do
+    @organization = organizations(:one)
+    @user = users(:one)
+    set_current_context(user: @user, organization: @organization)
+  end
+
+  test "screens clean transaction as low risk" do
+    transaction = transactions(:purchase)
+    result = Transactions::Screen.call(transaction: transaction)
+
+    assert result.success?
+    assert_equal "LOW", result.record[:risk_score]
+    assert_not result.record[:recommend_str]
+  end
+
+  test "flags cash transaction above threshold" do
+    transaction = transactions(:cash_payment)
+    result = Transactions::Screen.call(transaction: transaction)
+
+    assert result.success?
+    if transaction.cash_amount.present? && transaction.cash_amount >= 10_000
+      assert result.record[:flags].any? { |f| f[:key] == :cash_threshold }
+      assert_equal "HIGH", result.record[:risk_score]
+      assert result.record[:recommend_str]
+    end
+  end
+
+  test "always returns screening result" do
+    transaction = transactions(:purchase)
+    result = Transactions::Screen.call(transaction: transaction)
+
+    assert result.success?
+    assert result.record.key?(:transaction_id)
+    assert result.record.key?(:flags)
+    assert result.record.key?(:risk_score)
+    assert result.record.key?(:recommend_str)
+    assert result.record.key?(:screened_at)
+  end
+end


### PR DESCRIPTION
Introduces three foundational layers to make the app accessible to AI agents
and CLI-based workflows:

Service Layer (app/services/):
- ServiceResult: lightweight result object for service operations
- Clients::Create, Update, Onboard, AssessRisk
- Submissions::Generate, Validate, Complete
- Transactions::Screen (AML flag detection)
- Compliance::Gaps (data completeness analysis)
- Compliance::RiskAssessment (organization-wide risk summary)

CRM API v1 (app/controllers/api/v1/):
- Full CRUD for clients, transactions, STR reports, managed properties, trainings
- Beneficial owners (nested under clients, shallow member routes)
- Submissions with complete/validate/download/preview actions
- Compliance endpoints (gaps, risk_assessment)
- Organization-scoped via ApiOrganizationScoped concern
- Reuses existing Pundit policies for authorization

CLI Client (bin/immo + lib/cli/):
- API client with token auth, JSON serialization, error handling
- Persistent config via ~/.immo.json
- Human-readable table output + JSON mode for piped/agent usage
- Commands for all CRM resources and compliance queries

Tests:
- Service unit tests (ServiceResult, Create, Onboard, AssessRisk, Screen, Gaps, RiskAssessment)
- API integration tests (clients, transactions, compliance, submissions)

https://claude.ai/code/session_01W8pTP6ik9mTu9KxquG4Rdn