### PR TITLE
fix: implement 5-year lookback for Q155-Q157 (aIR237B, aIR238B, aIR239B)

### DIFF
--- a/app/models/survey/fields/products_services_risk.rb
+++ b/app/models/survey/fields/products_services_risk.rb
@@ -341,28 +341,22 @@ class Survey
         natural_counts.merge(legal_counts) { |_key, v1, v2| v1 + v2 }
       end
 
-      # Rental transactions, grouped by property country
+      # Q155: Total purchase/sale transactions over 5 years, by client nationality
       def air237b
-        year_transactions.rentals
-          .where.not(property_country: [nil, ""])
-          .group(:property_country)
-          .count
+        scope = five_year_transactions.where(transaction_type: %w[PURCHASE SALE])
+        transactions_by_client_country(scope, aggregate: :count)
       end
 
-      # Rental transaction values, grouped by property country
+      # Q156: Total funds for purchase/sale in current year, by client nationality
       def air238b
-        year_transactions.rentals
-          .where.not(property_country: [nil, ""])
-          .group(:property_country)
-          .sum(:transaction_value)
+        scope = year_transactions.where(transaction_type: %w[PURCHASE SALE])
+        transactions_by_client_country(scope, aggregate: :sum)
       end
 
-      # Additional rental value metric, grouped by property country
+      # Q157: Total funds for purchase/sale over 5 years, by client nationality
       def air239b
-        year_transactions.rentals
-          .where.not(property_country: [nil, ""])
-          .group(:property_country)
-          .sum(:rental_annual_value)
+        scope = five_year_transactions.where(transaction_type: %w[PURCHASE SALE])
+        transactions_by_client_country(scope, aggregate: :sum)
       end
     end
   end

--- a/docs/survey_audit_log.md
+++ b/docs/survey_audit_log.md
@@ -1,0 +1,57 @@
+# AMSF Survey Audit Log
+
+Bugs and mismatches found by cross-referencing the AMSF questionnaire (French source text + gem taxonomy) against the Survey field implementations.
+
+## Bugs Found
+
+### 1. `ab3206` / `ab3207` in controls.rb — Wrong field IDs
+- **PR:** #98
+- **Fields:** `aB3206` (Q173), `aB3207` (Q174)
+- **Expected:** Count of new natural person / legal entity clients in reporting period
+- **Actual:** `ab3206` returned training staff count (`organization.trainings.for_year(year).sum(:staff_count)`), `ab3207` returned a setting value
+- **Root cause:** Field IDs were incorrectly assigned to training methods in controls.rb. The training methods should be `ac1102a` / `ac1102`.
+- **Impact:** Survey would report training headcount instead of new client counts. Both values are integers so no type error — silent wrong data.
+
+### 2. `air233b` / `air233s` — Counting transactions instead of unique clients
+- **PR:** #99
+- **Fields:** `aIR233B` (Q150), `aIR233S` (Q151)
+- **Expected:** "Combien de clients uniques étaient des acheteurs/vendeurs?" — count of **unique clients** who were buyers/sellers
+- **Actual:** Counted number of purchase/sale transactions (`.count` instead of `.distinct.count(:client_id)`)
+- **Root cause:** Subtle mistranslation — "how many" was interpreted as transaction count rather than unique client count
+- **Impact:** A client with 3 purchases would be counted as 3 instead of 1. Inflated buyer/seller numbers.
+
+### 3. `a3208tola` in distribution_risk.rb — Hardcoded to 0
+- **PR:** #98
+- **Field:** `a3208TOLA` (Q175)
+- **Expected:** Count of new trust/legal construction clients in reporting period
+- **Actual:** Returned hardcoded `0` with comment about non-face-to-face tracking
+- **Root cause:** Field was mistakenly associated with non-face-to-face relationships instead of new client onboarding
+- **Impact:** Trust client count always reported as 0 regardless of actual data.
+
+### 4. `air237b` — Rental transactions instead of 5-year purchase/sale count by nationality
+- **PR:** #100
+- **Field:** `aIR237B` (Q155)
+- **Expected:** "Total transactions for purchases/sales over reporting period + 4 previous years, by client nationality"
+- **Actual:** Counted rental transactions grouped by property_country (wrong transaction type, wrong grouping dimension, wrong time range)
+- **Root cause:** Method was incorrectly implementing a rental query instead of the 5-year purchase/sale lookback
+- **Impact:** Completely wrong data — rental counts by property location instead of purchase/sale counts by client nationality over 5 years
+
+### 5. `air238b` — Rental values instead of current-year purchase/sale funds by nationality
+- **PR:** #100
+- **Field:** `aIR238B` (Q156)
+- **Expected:** "Total funds for purchases/sales in current year, by client nationality"
+- **Actual:** Summed rental transaction_value by property_country
+- **Root cause:** Same as #4 — rental query instead of purchase/sale
+- **Impact:** Rental values reported instead of purchase/sale amounts
+
+### 6. `air239b` — Rental annual values instead of 5-year purchase/sale funds by nationality
+- **PR:** #100
+- **Field:** `aIR239B` (Q157)
+- **Expected:** "Total funds for purchases/sales over 5 years, by client nationality"
+- **Actual:** Summed rental_annual_value by property_country
+- **Root cause:** Same as #4/#5
+- **Impact:** Rental annual values reported instead of purchase/sale funds over 5 years
+
+---
+
+*This log is maintained as part of the AMSF gap analysis work. Each survey method gets a semantic audit against the French source questionnaire and the gem's taxonomy structure before implementation.*

--- a/test/models/survey/fields/five_year_lookback_test.rb
+++ b/test/models/survey/fields/five_year_lookback_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Survey::Fields::FiveYearLookbackTest < ActiveSupport::TestCase
+  setup do
+    @account = Account.create!(owner: users(:one), name: "Lookback Test Account", personal: false)
+    @org = Organization.create!(account: @account, name: "Lookback Test Agency", rci_number: "LBK001")
+    @survey = Survey.new(organization: @org, year: 2025)
+
+    @french_np = Client.create!(organization: @org, name: "French Buyer", client_type: "NATURAL_PERSON", nationality: "FR")
+    @italian_np = Client.create!(organization: @org, name: "Italian Buyer", client_type: "NATURAL_PERSON", nationality: "IT")
+    @monaco_le = Client.create!(organization: @org, name: "Monaco SCI", client_type: "LEGAL_ENTITY", legal_entity_type: "SCI", incorporation_country: "MC")
+  end
+
+  # === Q155: air237b — 5-year transaction count by nationality ===
+
+  test "air237b returns empty hash when no transactions exist" do
+    assert_equal({}, @survey.send(:air237b))
+  end
+
+  test "air237b counts purchase/sale transactions grouped by client nationality" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "SALE", transaction_date: Date.new(2025, 6, 1), transaction_value: 600_000)
+    Transaction.create!(organization: @org, client: @italian_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 4, 1), transaction_value: 400_000)
+
+    result = @survey.send(:air237b)
+    assert_equal 2, result["FR"]
+    assert_equal 1, result["IT"]
+  end
+
+  test "air237b includes transactions from 4 previous years" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2021, 6, 1), transaction_value: 300_000)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "SALE", transaction_date: Date.new(2023, 6, 1), transaction_value: 400_000)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 6, 1), transaction_value: 500_000)
+
+    result = @survey.send(:air237b)
+    assert_equal 3, result["FR"]
+  end
+
+  test "air237b excludes transactions older than 5 years" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2020, 12, 31), transaction_value: 300_000)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2021, 1, 1), transaction_value: 400_000)
+
+    result = @survey.send(:air237b)
+    assert_equal 1, result["FR"]
+  end
+
+  test "air237b excludes rental transactions" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "RENTAL", transaction_date: Date.new(2025, 3, 1), transaction_value: 15_000)
+
+    assert_equal({}, @survey.send(:air237b))
+  end
+
+  test "air237b merges natural person nationality and legal entity incorporation country" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: @monaco_le, transaction_type: "SALE", transaction_date: Date.new(2025, 4, 1), transaction_value: 800_000)
+
+    result = @survey.send(:air237b)
+    assert_equal 1, result["FR"]
+    assert_equal 1, result["MC"]
+  end
+
+  test "air237b merges counts when NP nationality matches LE incorporation country" do
+    french_le = Client.create!(organization: @org, name: "French SARL", client_type: "LEGAL_ENTITY", legal_entity_type: "SARL", incorporation_country: "FR")
+
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: french_le, transaction_type: "SALE", transaction_date: Date.new(2025, 4, 1), transaction_value: 600_000)
+
+    result = @survey.send(:air237b)
+    assert_equal 2, result["FR"]
+  end
+
+  # === Q156: air238b — Current year funds by nationality ===
+
+  test "air238b returns empty hash when no transactions exist" do
+    assert_equal({}, @survey.send(:air238b))
+  end
+
+  test "air238b sums purchase/sale values for current year by nationality" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "SALE", transaction_date: Date.new(2025, 6, 1), transaction_value: 300_000)
+    Transaction.create!(organization: @org, client: @italian_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 4, 1), transaction_value: 400_000)
+
+    result = @survey.send(:air238b)
+    assert_equal 800_000, result["FR"]
+    assert_equal 400_000, result["IT"]
+  end
+
+  test "air238b excludes transactions from other years" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2024, 12, 31), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 1, 1), transaction_value: 300_000)
+
+    result = @survey.send(:air238b)
+    assert_equal 300_000, result["FR"]
+  end
+
+  test "air238b excludes rental transactions" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "RENTAL", transaction_date: Date.new(2025, 3, 1), transaction_value: 15_000)
+
+    assert_equal({}, @survey.send(:air238b))
+  end
+
+  # === Q157: air239b — 5-year funds by nationality ===
+
+  test "air239b returns empty hash when no transactions exist" do
+    assert_equal({}, @survey.send(:air239b))
+  end
+
+  test "air239b sums purchase/sale values over 5 years by nationality" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2021, 3, 1), transaction_value: 200_000)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "SALE", transaction_date: Date.new(2023, 6, 1), transaction_value: 300_000)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 6, 1), transaction_value: 500_000)
+
+    result = @survey.send(:air239b)
+    assert_equal 1_000_000, result["FR"]
+  end
+
+  test "air239b excludes transactions older than 5 years" do
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2020, 12, 31), transaction_value: 999_999)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2021, 1, 1), transaction_value: 100_000)
+
+    result = @survey.send(:air239b)
+    assert_equal 100_000, result["FR"]
+  end
+
+  # === Helper: five_year_transactions ===
+
+  test "five_year_transactions includes exactly years year-4 through year" do
+    # year = 2025, so range is 2021-01-01 to 2025-12-31
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2020, 12, 31), transaction_value: 100)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2021, 1, 1), transaction_value: 200)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 12, 31), transaction_value: 300)
+    Transaction.create!(organization: @org, client: @french_np, transaction_type: "PURCHASE", transaction_date: Date.new(2026, 1, 1), transaction_value: 400)
+
+    assert_equal 2, @survey.send(:five_year_transactions).count
+  end
+end


### PR DESCRIPTION
## Bug Fix — Q155/Q156/Q157: Completely wrong data source

### Problem
All three methods were querying **rental** transactions grouped by **property country** instead of **purchase/sale** transactions grouped by **client nationality**.

| Method | Expected | Was doing |
|--------|----------|-----------|
| `air237b` (Q155) | 5-year P/S transaction count by nationality | Rental count by property country |
| `air238b` (Q156) | Current year P/S funds by nationality | Rental values by property country |
| `air239b` (Q157) | 5-year P/S funds by nationality | Rental annual values by property country |

### Fix
- New `five_year_transactions` helper in Helpers module
- New `transactions_by_client_country` helper that merges NP nationality + LE incorporation_country
- All three methods now query correct transaction types, time ranges, and grouping dimensions

### Tests
15 new tests covering:
- [x] Empty data returns empty hash
- [x] Correct nationality grouping (NP + LE merged)
- [x] 5-year range boundaries (year-4 to year)
- [x] Excludes older transactions
- [x] Excludes rental transactions
- [x] Correct aggregation (count vs sum)

All 37 survey tests pass.

See `docs/survey_audit_log.md` for the full bug catalog.