### PR TITLE
fix: count investment purchases not new construction for Q158 (aIR117)

### DIFF
--- a/app/models/survey/fields/products_services_risk.rb
+++ b/app/models/survey/fields/products_services_risk.rb
@@ -243,9 +243,12 @@ class Survey
         year_transactions.sales.count
       end
 
+      # Q158: Purchases and sales for investment (excluding primary residence)
       def air117
-        # Specific count (new construction purchases)
-        year_transactions.purchases.where(is_new_construction: true).count
+        year_transactions
+          .where(transaction_type: %w[PURCHASE SALE])
+          .where(purchase_purpose: "INVESTMENT")
+          .count
       end
 
       def air2391

--- a/test/models/survey/fields/investment_purchases_test.rb
+++ b/test/models/survey/fields/investment_purchases_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Survey::Fields::InvestmentPurchasesTest < ActiveSupport::TestCase
+  setup do
+    @account = Account.create!(owner: users(:one), name: "Investment Test Account", personal: false)
+    @org = Organization.create!(account: @account, name: "Investment Test Agency", rci_number: "INV001")
+    @survey = Survey.new(organization: @org, year: 2025)
+    @client = Client.create!(organization: @org, name: "Buyer", client_type: "NATURAL_PERSON")
+  end
+
+  test "air117 returns 0 when no transactions exist" do
+    assert_equal 0, @survey.send(:air117)
+  end
+
+  test "air117 counts purchases with investment purpose" do
+    Transaction.create!(organization: @org, client: @client, transaction_type: "PURCHASE", purchase_purpose: "INVESTMENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+
+    assert_equal 1, @survey.send(:air117)
+  end
+
+  test "air117 counts sales with investment purpose" do
+    Transaction.create!(organization: @org, client: @client, transaction_type: "SALE", purchase_purpose: "INVESTMENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+
+    assert_equal 1, @survey.send(:air117)
+  end
+
+  test "air117 excludes residence purpose transactions" do
+    Transaction.create!(organization: @org, client: @client, transaction_type: "PURCHASE", purchase_purpose: "RESIDENCE", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: @client, transaction_type: "PURCHASE", purchase_purpose: "INVESTMENT", transaction_date: Date.new(2025, 4, 1), transaction_value: 600_000)
+
+    assert_equal 1, @survey.send(:air117)
+  end
+
+  test "air117 excludes rental transactions" do
+    Transaction.create!(organization: @org, client: @client, transaction_type: "RENTAL", purchase_purpose: "INVESTMENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 15_000)
+
+    assert_equal 0, @survey.send(:air117)
+  end
+
+  test "air117 excludes transactions from other years" do
+    Transaction.create!(organization: @org, client: @client, transaction_type: "PURCHASE", purchase_purpose: "INVESTMENT", transaction_date: Date.new(2024, 12, 31), transaction_value: 500_000)
+
+    assert_equal 0, @survey.send(:air117)
+  end
+
+  test "air117 excludes transactions with nil purchase purpose" do
+    Transaction.create!(organization: @org, client: @client, transaction_type: "PURCHASE", purchase_purpose: nil, transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+
+    assert_equal 0, @survey.send(:air117)
+  end
+
+  test "air117 excludes soft-deleted transactions" do
+    Transaction.create!(organization: @org, client: @client, transaction_type: "PURCHASE", purchase_purpose: "INVESTMENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000, deleted_at: Time.current)
+
+    assert_equal 0, @survey.send(:air117)
+  end
+end


### PR DESCRIPTION
## Bug Fix — Q158: Wrong filter criterion

### Problem
`air117` (Q158) asks: "How many purchases/sales were for **investment**, excluding properties used as primary residence?"

The method was filtering by `is_new_construction: true` instead of `purchase_purpose: "INVESTMENT"`.

### Fix
Filter by `purchase_purpose: "INVESTMENT"` on purchases and sales.

### Tests
8 new tests covering:
- [x] Investment purpose counted
- [x] Sales with investment purpose included
- [x] Residence purpose excluded
- [x] Nil purpose excluded
- [x] Rental transactions excluded
- [x] Year filtering
- [x] Soft-deleted excluded

All 30 survey tests pass.

**Bug #7** in the audit log — see `docs/survey_audit_log.md` on the Q155-Q157 branch.