### PR TITLE
fix: survey audit round 2 — 15 semantic fixes across all modules

### DIFF
--- a/app/models/survey/fields/controls.rb
+++ b/app/models/survey/fields/controls.rb
@@ -125,11 +125,9 @@ class Survey
         setting_value("parent_company_country")
       end
 
+      # Q198: Has entity had significant changes (management, shareholders, statutes) during period?
       def a3307
-        clients_kept
-          .legal_entities
-          .where(due_diligence_level: "REINFORCED")
-          .exists? ? "Oui" : "Non"
+        setting_value("a3307") || "Non"
       end
 
       def a3308
@@ -244,13 +242,9 @@ class Survey
 
       # === SAR (Suspicious Activity Reports) ===
 
+      # C1: Total number of employees (including non-salaried partners/owners)
       def ac1102a
-        year_start = Date.new(year, 1, 1)
-        year_end = Date.new(year, 12, 31)
-
-        organization.str_reports.kept
-          .where(report_date: year_start..year_end)
-          .count
+        setting_value("total_employees")&.to_i || 0
       end
 
       # Total FTE employees plus non-salaried partners/owners

--- a/app/models/survey/fields/customer_risk.rb
+++ b/app/models/survey/fields/customer_risk.rb
@@ -38,24 +38,24 @@ class Survey
 
       # === Client Totals ===
 
-      # Total number of unique clients active during the period
+      # Q4: Total number of unique clients active during the period
       def a1101
-        organization.clients.count
+        clients_kept.count
       end
 
-      # Clients who are Monegasque nationals
+      # Q23: Natural person clients who are Monegasque nationals
       def a1102
-        clients_kept.where(nationality: "MC").count
+        clients_kept.natural_persons.where(nationality: "MC").count
       end
 
-      # Clients who are foreign residents (not MC nationals but residents)
+      # Q24: Natural person clients who are foreign residents
       def a1103
-        clients_kept.where(residence_status: "RESIDENT").where.not(nationality: "MC").count
+        clients_kept.natural_persons.where(residence_status: "RESIDENT").where.not(nationality: "MC").count
       end
 
-      # Clients who are non-residents
+      # Q25: Natural person clients who are non-residents
       def a1104
-        clients_kept.where(residence_status: "NON_RESIDENT").count
+        clients_kept.natural_persons.where(residence_status: "NON_RESIDENT").count
       end
 
       # === Natural Person Statistics ===
@@ -71,11 +71,13 @@ class Survey
       end
 
       # Total funds transferred by individual clients
+      # Q28: Total funds transferred by natural person clients for purchases and sales
       def a1404b
         year_transactions
           .by_client
           .joins(:client)
           .merge(Client.natural_persons)
+          .where(transaction_type: %w[PURCHASE SALE])
           .sum(:transaction_value)
       end
 
@@ -103,31 +105,24 @@ class Survey
       # === Legal Entity Statistics ===
 
       # Transactions by legal entity clients (excluding trusts, counted separately in a1806tola)
+      # Q34: Transactions by legal entity clients for purchases and sales (excluding trusts)
       def a1502b
-        purchases_and_sales = year_transactions
+        year_transactions
           .by_client
           .joins(:client)
           .merge(Client.legal_entities.where.not(legal_entity_type: "TRUST"))
           .where(transaction_type: %w[PURCHASE SALE])
           .count
-
-        rental_months = year_transactions
-          .by_client
-          .joins(:client)
-          .merge(Client.legal_entities.where.not(legal_entity_type: "TRUST"))
-          .rentals
-          .where(transaction_value: 10_000..)
-          .sum(:rental_duration_months)
-
-        purchases_and_sales + rental_months
       end
 
       # Total funds from legal entity transactions (excluding trusts, counted separately in a1807tola)
+      # Q35: Total funds from legal entity clients for purchases and sales (excluding trusts)
       def a1503b
         year_transactions
           .by_client
           .joins(:client)
           .merge(Client.legal_entities.where.not(legal_entity_type: "TRUST"))
+          .where(transaction_type: %w[PURCHASE SALE])
           .sum(:transaction_value)
       end
 
@@ -164,31 +159,24 @@ class Survey
       end
 
       # Transactions by trust clients
+      # Q46: Transactions by trust clients for purchases and sales
       def a1806tola
-        purchases_and_sales = year_transactions
+        year_transactions
           .by_client
           .joins(:client)
           .merge(Client.trusts)
           .where(transaction_type: %w[PURCHASE SALE])
           .count
-
-        rental_months = year_transactions
-          .by_client
-          .joins(:client)
-          .merge(Client.trusts)
-          .rentals
-          .where(transaction_value: 10_000..)
-          .sum(:rental_duration_months)
-
-        purchases_and_sales + rental_months
       end
 
       # Total funds from trust transactions
+      # Q47: Total funds from trust clients for purchases and sales
       def a1807tola
         year_transactions
           .by_client
           .joins(:client)
           .merge(Client.trusts)
+          .where(transaction_type: %w[PURCHASE SALE])
           .sum(:transaction_value)
       end
 
@@ -223,18 +211,21 @@ class Survey
       end
 
       # Transactions by PEP clients
+      # Q52: Transactions by PEP clients for purchases and sales
       def a11304b
         year_transactions
           .joins(:client)
           .merge(Client.peps)
+          .where(transaction_type: %w[PURCHASE SALE])
           .count
       end
 
-      # Total funds from PEP transactions
+      # Q53: Total funds from PEP clients for purchases and sales
       def a11305b
         year_transactions
           .joins(:client)
           .merge(Client.peps)
+          .where(transaction_type: %w[PURCHASE SALE])
           .sum(:transaction_value)
       end
 
@@ -411,9 +402,9 @@ class Survey
         purchases_and_sales + rental_months
       end
 
-      # Funds transferred BY clients (client pays directly)
+      # Q6: Funds transferred BY clients for purchases and sales only
       def a1106b
-        year_transactions.by_client.sum(:transaction_value)
+        year_transactions.by_client.where(transaction_type: %w[PURCHASE SALE]).sum(:transaction_value)
       end
 
       # Funds transferred for rentals
@@ -421,9 +412,16 @@ class Survey
         year_transactions.rentals.sum(:transaction_value)
       end
 
-      # Transactions WITH clients (funds flow through agency)
+      # Q8: Transactions WITH clients (each rental month ≥€10k = 1 transaction per AMSF)
       def a1105w
-        year_transactions.with_client.count
+        purchases_and_sales = year_transactions.with_client.where(transaction_type: %w[PURCHASE SALE]).count
+
+        rental_months = year_transactions.with_client
+          .rentals
+          .where(transaction_value: 10_000..)
+          .sum(:rental_duration_months)
+
+        purchases_and_sales + rental_months
       end
 
       # Funds transferred WITH clients (funds flow through agency)

--- a/app/models/survey/fields/helpers.rb
+++ b/app/models/survey/fields/helpers.rb
@@ -44,9 +44,10 @@ class Survey
           .transform_values(&:value)
       end
 
-      # Count clients by business sector
+      # Count Monegasque clients by business sector (Q81-Q109)
+      # Questions ask for "clients uniques monégasques" in each sector
       def clients_by_sector(sector)
-        clients_kept.where(business_sector: sector).count
+        clients_kept.where(business_sector: sector, nationality: "MC").count
       end
 
       # Count VASP transactions by VASP type

--- a/app/models/survey/fields/products_services_risk.rb
+++ b/app/models/survey/fields/products_services_risk.rb
@@ -96,9 +96,10 @@ class Survey
         year_transactions.with_client.with_cash.sum(:cash_amount)
       end
 
+      # Q130: Total value of cash payments in non-EUR currencies WITH clients
+      # Requires cash_currency field on transactions — returns 0 until schema supports it
       def ag24010w
-        # Total transaction value by property location
-        year_transactions.where.not(property_country: [nil, ""]).sum(:transaction_value)
+        0
       end
 
       def a2110w
@@ -151,9 +152,10 @@ class Survey
         year_transactions.by_client.with_cash.sum(:cash_amount)
       end
 
+      # Q139: Total value of cash payments in non-EUR currencies BY clients
+      # Requires cash_currency field on transactions — returns 0 until schema supports it
       def ag24010b
-        # Value of transactions by client property location
-        year_transactions.by_client.where.not(property_country: [nil, ""]).sum(:transaction_value)
+        0
       end
 
       def a2110b
@@ -273,23 +275,19 @@ class Survey
         year_transactions.rentals.count
       end
 
+      # Q164: Unique rental properties with monthly rent ≥ €10,000
       def air2313
-        # Unique rental properties with monthly rent > 10,000
-        year_transactions
-          .rentals
-          .where("rental_annual_value > ?", 120000)  # > 10k/month = > 120k/year
-          .select(:client_id)
-          .distinct
+        organization.managed_properties
+          .active_in_year(year)
+          .where("monthly_rent >= ?", 10_000)
           .count
       end
 
+      # Q165: Unique rental properties with monthly rent < €10,000
       def air2316
-        # Unique rental properties with monthly rent <= 10,000
-        year_transactions
-          .rentals
-          .where("rental_annual_value <= ? OR rental_annual_value IS NULL", 120000)
-          .select(:client_id)
-          .distinct
+        organization.managed_properties
+          .active_in_year(year)
+          .where("monthly_rent < ? OR monthly_rent IS NULL", 10_000)
           .count
       end
 
@@ -305,13 +303,23 @@ class Survey
 
       # === Additional Transaction Dimensional Fields ===
 
+      # Q149: Total unique clients, grouped by nationality
+      # Natural persons: grouped by nationality
+      # Legal entities: grouped by incorporation_country
       def air233
-        # Total transactions where agency acted as agent, grouped by property country
-        year_transactions
-          .where.not(agency_role: [nil, ""])
-          .where.not(property_country: [nil, ""])
-          .group(:property_country)
+        natural = clients_kept
+          .natural_persons
+          .where.not(nationality: [nil, ""])
+          .group(:nationality)
           .count
+
+        legal = clients_kept
+          .legal_entities
+          .where.not(incorporation_country: [nil, ""])
+          .group(:incorporation_country)
+          .count
+
+        natural.merge(legal) { |_k, v1, v2| v1 + v2 }
       end
 
       # Purchase/sale transactions by clients, grouped by client country

--- a/app/models/survey/fields/signatories.rb
+++ b/app/models/survey/fields/signatories.rb
@@ -85,9 +85,9 @@ class Survey
         setting_value("annual_revenue")&.to_i || 0
       end
 
-      # Total unique clients (repeat of a1101)
+      # C51: Total unique clients (repeat of a1101 — uses clients_kept scope)
       def ac1611
-        organization.clients.count
+        clients_kept.count
       end
 
       # High-risk clients count

--- a/docs/full_survey_audit.md
+++ b/docs/full_survey_audit.md
@@ -1,0 +1,702 @@
+# Complete Semantic Audit of AMSF Survey Field Methods
+
+**Date:** 2026-02-11  
+**Auditor:** Ada 🦉  
+**Audited against:** Master branch (currently deployed)  
+**Reference:** `questionnaire_structure.yml` (2025 taxonomy) + `amsf_questions.csv`
+
+> **Legend:**
+> ✅ Correct | ⚠️ Partially correct | ❌ Wrong | 🔧 Fixed in PR (not yet on master) | ❓ Setting (can't verify without org data) | 📐 Dimensional field
+
+---
+
+## 1. Customer Risk (`customer_risk.rb`)
+
+### 1.1 Activity Indicators
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `aactive` | aACTIVE | Q1 | Has agency had professional activity (purchases, sales, rentals ≥€10k/mo)? | ✅ | Checks `year_transactions.exists?` |
+| `aactiveps` | aACTIVEPS | Q2 | Specifically purchase/sale activity? | ✅ | Checks purchases OR sales exist |
+| `aactiverentals` | aACTIVERENTALS | Q3 | Rental activity (monthly rent ≥€10k)? | ✅ | Filters `transaction_value: 10_000..` |
+
+### 1.2 Client Totals
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a1101` | a1101 | Q4 | Total unique clients active during period | ⚠️ | Uses `organization.clients.count` — not filtered by `kept` scope or year activity. Should only count clients active in reporting period with qualifying transactions. Overcounts. |
+| `a1102` | a1102 | Q23 | Monegasque national clients (natural persons) | ⚠️ | Counts all MC nationality clients in `clients_kept`, not limited to natural persons. Q23 specifically asks for natural persons ("personnes physiques qui sont des nationaux"). |
+| `a1103` | a1103 | Q24 | Foreign resident clients (natural persons) | ⚠️ | Same issue — not filtered to natural persons. Q24 asks for natural persons who are foreign residents. |
+| `a1104` | a1104 | Q25 | Non-resident clients (natural persons) | ⚠️ | Same issue — not filtered to natural persons. |
+
+### 1.3 Natural Person Statistics
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a1403b` | a1403B | Q27 | Transactions by natural person clients (purchase/sale) | ✅ | Correctly joins clients, filters natural persons, purchase/sale types |
+| `a1404b` | a1404B | Q28 | Total funds transferred by natural person clients | ⚠️ | Sums all transaction_value for natural persons — not limited to purchases/sales. Q28 says "pour l'achat et la vente" (purchases and sales only). Includes rentals. |
+| `a1401r` | a1401R | Q29 | Natural person clients with rental activity | ✅ | Correctly counts distinct natural person clients with rental transactions |
+| `a1403r` | a1403R | Q30 | Rental transactions by natural person clients | ✅ | Sums rental_duration_months for rentals ≥€10k — matches AMSF definition of rental transactions |
+
+### 1.4 Legal Entity Statistics
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a1502b` | a1502B | Q34 | Transactions by legal entity clients (excluding trusts) | ⚠️ | Combines purchase/sale count + rental months. Q34 only asks for "achats et ventes" — should NOT include rentals. |
+| `a1503b` | a1503B | Q35 | Total funds from legal entity clients | ⚠️ | Sums all transaction_value for legal entities (excl trusts). Q35 says "pour l'achat et la vente" — should exclude rentals. |
+| `a155` | a155 | Q36 | Does entity identify Monaco legal entity types? | ❓ | Setting value |
+
+### 1.5 Trust Statistics
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a1802btola` | a1802BTOLA | Q40 | Does entity distinguish trust clients? | ✅ | Derived from data |
+| `a1802tola` | a1802TOLA | Q41 | Number of trust clients | ✅ | `clients_kept.trusts.count` |
+| `a1807atola` | a1807ATOLA | Q42 | Monaco-based trusts | ✅ | Filters by `incorporation_country: "MC"` |
+| `a1808` | a1808 | Q43 | Professional trustees by nationality | ✅ | Correctly groups professional trustees by nationality |
+| `a1809` | a1809 | Q44 | Professional trustees by country where trust was created | ✅ | Groups by `clients.incorporation_country` — correct per AMSF |
+| `a11001btola` | a11001BTOLA | Q45 | Can entity provide trust transaction info? | ✅ | Delegates to `a1806tola.positive?` |
+| `a1806tola` | a1806TOLA | Q46 | Transactions by trust clients | ⚠️ | Combines purchase/sale count + rental months. Q46 says "pour l'achat et la vente" — should NOT include rentals. |
+| `a1807tola` | a1807TOLA | Q47 | Total funds from trust clients | ⚠️ | Sums all transaction_value including rentals. Q47 says "pour l'achat et la vente". |
+| `a11006` | a11006 | Q48 | Other legal arrangement types | ✅ | Correctly derives from client data |
+
+### 1.6 PEP Statistics
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a11301` | a11301 | Q49 | Has PEP clients? | ✅ | |
+| `a11304b` | a11304B | Q52 | Transactions by PEP clients (purchase/sale) | ⚠️ | Counts ALL transactions by PEP clients. Q52 says "pour l'achat et la vente" — should filter to purchase/sale only. |
+| `a11305b` | a11305B | Q53 | Total funds from PEP clients (purchase/sale) | ⚠️ | Sums all transaction_value. Q53 says "pour l'achat et la vente" — should filter. |
+| `a11309b` | a11309B | Q55 | Transactions with PEP beneficial owners | ⚠️ | Counts all transactions, not limited to purchase/sale. Q55 doesn't specify P&S only, but the scope context of section 1.8 implies it. Borderline. |
+
+### 1.7 VASP Statistics
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a13501b` | a13501B | Q56 | Has VASP clients? | ✅ | |
+| `a13601a` | a13601A | Q57 | Distinguishes custodian wallet VASPs? | ❓ | Setting |
+| `a13601cw` | a13601CW | Q58 | Has custodian wallet VASP clients? | ✅ | Derived from data |
+| `a13603bb` | a13603BB | Q59 | Custodian VASP clients by country | ❌ | **Returns transaction count, but Q59 asks for unique clients by country of establishment (dimensional).** Should return grouped hash like `vasp_clients_grouped_by_country("CUSTODIAN")`. |
+| `a13604bb` | a13604BB | Q60 | Transactions by custodian VASP clients | ⚠️ | Returns transaction count. Q60 asks for total transactions — could be correct, but field naming suggests this should be the funds total (Q61 in taxonomy maps to a13604BB for funds). Cross-check: taxonomy says Q60 = a13603BB (count), Q61 = a13604BB (funds). So a13604bb returning funds is ✅, but a13603bb returning count when Q59 wants clients by country is ❌. Wait — re-reading taxonomy: Q59 = a13602B (clients by country), Q60 = a13603BB (transaction count), Q61 = a13604BB (funds). Let me re-check. |
+| `a13601b` | a13601B | Q61 | Funds from custodian VASP clients | ⚠️ | This returns a setting value. But Q61 = a13604BB per the taxonomy layout. Actually the taxonomy maps a13601B to Q61 which asks about funds value for custodian VASPs. But the method returns `setting_value("a13601b") || "Non"` — a Yes/No. Reviewing: taxonomy Q61 field_id is a13601B, and Q61 text is "Veuillez indiquer la valeur totale des fonds..." — this seems like a taxonomy mapping confusion. Actually looking more carefully, Q61's field_id IS a13601B and it asks about the value of funds. The method returns "Non" default. This is likely a **taxonomy misread** — a13601B seems like a gate question ("does entity distinguish exchange VASPs"), not a funds value. The taxonomy numbering is peculiar here. The setting approach seems correct for the gate question pattern. |
+| `a13601ep` | a13601EP | Q62 | Has exchange VASP clients? | ✅ | |
+| `a13603ab` | a13603AB | Q63 | Exchange VASP clients by country | ❌ | **Same issue as a13603bb — returns transaction count, but Q63 asks for unique clients by country of establishment.** Actually re-reading: Q63 = a13601EP? No. Q63 field_id = a13603AB. Q63 asks "Votre entité a-t-elle des clients PSAV qui sont des fournisseurs d'échange de monnaie virtuelle?" — has exchange VASP clients? This is Yes/No. But method returns a count. Actually, Q63's field_id is a13603AB and Q64's is a13604AB. The CSV says Q63 asks "Votre entité a-t-elle des clients PSAV qui sont des fournisseurs d'échange de monnaie virtuelle?" — but wait, that looks like Q63 in the CSV while Q64 in the taxonomy asks for clients by country. Let me be more careful — I'll trust the taxonomy YAML over the CSV. Taxonomy: a13603AB = Q63, instruction = "Virtual Currency Exchange Providers". The pattern matches: 13603 = transaction count. So this method returns transaction count for exchange VASPs — which matches the taxonomic pattern for "number of transactions." ✅ after review. |
+| `a13604ab` | a13604AB | Q64 | Funds from exchange VASP clients | ✅ | Returns sum of transaction values |
+| `a13601c` | a13601C | Q65 | Distinguishes ICO VASPs? | ❓ | Setting |
+| `a13601ico` | a13601ICO | Q66 | Has ICO VASP clients? | ✅ | |
+| `a13603cacb` | a13603CACB | Q67 | ICO VASP clients by country | ✅ | Returns transaction count (matches 13603 pattern) |
+| `a13604cb` | a13604CB | Q68 | Funds from ICO VASP clients | ✅ | |
+| `a13601c2` | a13601C2 | Q69 | Distinguishes other VASPs? | ❓ | Setting |
+| `a13601other` | a13601OTHER | Q70 | Has other VASP clients? | ✅ | |
+| `a13603db` | a13603DB | Q71 | Other VASP transaction count | ✅ | |
+| `a13604db` | a13604DB | Q72 | Other VASP funds | ✅ | |
+| `a13602b` | a13602B | Q73 | Custodian VASP clients by country (dimensional) | 📐 ✅ | Returns grouped hash by country |
+| `a13602a` | a13602A | Q74 | Exchange VASP clients by country (dimensional) | 📐 ✅ | |
+| `a13602c` | a13602C | Q75 | ICO VASP clients by country (dimensional) | 📐 ✅ | |
+| `a13602d` | a13602D | Q76 | Other VASP clients by country (dimensional) | 📐 ✅ | |
+| `a13604e` | a13604E | Q77 | Other VASP services description | ✅ | Derives from client data |
+
+**Note:** After careful review of VASP fields, the taxonomy maps a13602* to dimensional client-by-country fields and a13603* to transaction counts. The code appears correct — my initial concern about a13603bb was unfounded. Revising: a13603bb = Q60 (transaction count for custodian VASPs) ✅. The Q59 (clients by country) is covered by a13602B = Q73.
+
+**Correction:** The taxonomy YAML lists questions in order: Q59=a13602B (custodian clients by country), Q60=a13603BB (transactions), Q61=a13604BB (funds). But the YAML numbering I see has Q59=a13603BB, Q60=a13604BB, Q61=a13601B. Let me re-verify. From the YAML:
+- a13603BB → Q59 
+- a13604BB → Q60
+- a13601B → Q61
+
+And a13602B → Q73. So:
+- Q59 asks for "nombre total de clients uniques PSAV... ventilé par pays d'établissement" — unique VASP clients by country
+- But field_id a13603BB is mapped to it, and our method `a13603bb` returns transaction count!
+
+**This IS a bug: `a13603bb` answers Q59 which asks for clients by country, not transaction count.**
+
+Let me finalize the VASP assessment properly:
+
+| Method | Field ID | Q# | Correct? | Issue |
+|--------|----------|----|----------|-------|
+| `a13603bb` | a13603BB | Q59 | ❌ | Q59 asks for unique custodian VASP clients by country. Method returns transaction count. Should return `vasp_clients_grouped_by_country("CUSTODIAN")`. |
+| `a13604bb` | a13604BB | Q60 | ❌ | Q60 asks for transaction count by custodian VASPs. Method returns funds sum. Should return count. |
+| `a13603ab` | a13603AB | Q63 | ❌ | Q63 asks "has exchange VASP clients?" — wait, CSV Q63 = "Votre entité a-t-elle des clients PSAV..." But taxonomy says a13603AB = Q63 with instruction "Virtual Currency Exchange Providers." Checking CSV: Q63 = "Votre entité a-t-elle des clients PSAV qui sont des fournisseurs d'échange de monnaie virtuelle?" That's a Yes/No! But the YAML maps it differently. The YAML Q62=a13601B, Q63=a13601EP, Q64=a13603AB... Actually let me re-read the YAML carefully. |
+
+**I need to be more careful. Let me re-map the VASP section from the YAML:**
+
+```
+Q56 = a13501B     → Has VASP clients?
+Q57 = a13601A     → Distinguishes custodian wallet VASPs?
+Q58 = a13601CW    → Has custodian wallet VASP clients?
+Q59 = a13603BB    → Custodian VASP clients by country  ← TEXT: "nombre total de clients uniques PSAV... ventilé par pays"
+Q60 = a13604BB    → Custodian VASP transactions
+Q61 = a13601B     → Custodian VASP funds
+Q62 = a13601EP    → Has exchange VASP clients?
+Q63 = a13603AB    → Exchange VASP clients by country  ← TEXT: "nombre total d'opérations" 
+Q64 = a13604AB    → Exchange VASP transactions/funds
+Q65 = a13601C     → Distinguishes ICO VASPs?
+Q66 = a13601ICO   → Has ICO VASP clients?
+Q67 = a13603CACB  → ICO client count by country
+Q68 = a13604CB    → ICO funds
+Q69 = a13601C2    → Distinguishes other VASPs?
+Q70 = a13601OTHER → Has other VASP clients?
+Q71 = a13603DB    → Other VASP transactions
+Q72 = a13604DB    → Other VASP funds
+Q73 = a13602B     → Custodian VASP clients by country (dimensional)
+Q74 = a13602A     → Exchange VASP clients by country (dimensional)
+Q75 = a13602C     → ICO VASP clients by country (dimensional)
+Q76 = a13602D     → Other VASP clients by country (dimensional)
+Q77 = a13604E     → Other VASP services description
+```
+
+Now cross-referencing with CSV:
+- Q59: "Veuillez indiquer le nombre total de clients uniques PSAV qui sont des prestataires de conservation (Custodian Wallet Providers), ventilé par pays d'établissement" → **clients by country** (dimensional)
+- Q60: "Veuillez indiquer le nombre total d'opérations effectuées par les clients PSAV qui sont des prestataires de conservation" → **transaction count**
+- Q61: "Veuillez indiquer la valeur totale des fonds transférés" → **funds value**
+
+So:
+- `a13603bb` → Q59 asks for **clients by country** → method returns `vasp_transactions_by_type("CUSTODIAN")` (transaction count) → ❌
+- `a13604bb` → Q60 asks for **transaction count** → method returns `vasp_funds_by_type("CUSTODIAN")` (funds sum) → ❌
+- `a13601b` → Q61 asks for **funds value** → method returns `setting_value("a13601b") || "Non"` → ❌
+
+Similarly for exchange:
+- Q63: "Votre entité a-t-elle des clients PSAV qui sont des fournisseurs d'échange de monnaie virtuelle?" (CSV) — but wait this is actually the text for the YAML's Q62 field. The CSV and YAML question numbers match but the field IDs differ. The CSV Q63 = "Votre entité a-t-elle des clients PSAV qui sont des fournisseurs d'échange de monnaie virtuelle?" which is a Yes/No. But YAML Q63 = a13603AB.
+
+**The CSV and YAML question numbers don't align for VASP section.** The CSV uses sequential numbering where Q62/Q63 are the "distinguishes?/has?" pair for exchange VASPs. The YAML maps field IDs to question numbers differently. 
+
+**Resolution:** The field_id → question_number mapping in the YAML is the authoritative source. The CSV may have different numbering. I'll trust the YAML mapping for field IDs and use the CSV for understanding what each question asks. The key question is: **what does each field_id mean per the AMSF taxonomy?**
+
+Looking at the VASP field naming pattern:
+- `a136XX` family: `01` = gate (setting), `02` = clients by country (dimensional), `03` = transaction count, `04` = funds value
+- Suffixes: `B`=custodian, `A`=exchange, `C`/`CAC`=ICO, `D`=other
+
+Given this naming convention:
+- `a13603BB` should be transaction count for custodian → method returns `vasp_transactions_by_type("CUSTODIAN")` → ✅ by naming convention
+- `a13604BB` should be funds for custodian → method returns `vasp_funds_by_type("CUSTODIAN")` → ✅ by naming convention
+- `a13601B` should be a gate question → method returns setting → ✅ by naming convention
+
+**The YAML's question_number mapping to French text creates confusion, but the code follows the correct field_id naming pattern.** The real question is whether the YAML correctly maps field_ids to question numbers. Given that the gem's taxonomy is authoritative, I'll treat the methods as following the field naming convention correctly. The YAML mapping may have errors, but that's a gem issue, not our code issue.
+
+**Final VASP verdict: All VASP methods follow the field naming convention correctly. ✅**
+
+### 1.8 Beneficial Owner Statistics
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a1204s` | a1204S | Q10 | Can identify BO nationality? | ❓ | Setting |
+| `a1204s1` | a1204S1 | Q11 | BO nationality breakdown (percentages) | 📐 ✅ | Returns percentage hash by nationality |
+| `a1202o` | a1202O | Q12 | BOs with direct/indirect control by nationality | 📐 ⚠️ | Counts ALL BOs by nationality, not filtered to those with direct/indirect control specifically. Should use `with_direct_or_indirect_control` scope if available. |
+| `a1202ob` | a1202OB | Q13 | BOs representing legal entities by nationality | 📐 ✅ | Correctly joins clients, filters legal entities |
+| `a1204o` | a1204O | Q14 | Can identify BOs with 25%+ ownership? | ❓ | Setting |
+| `a120425o` | a120425O | Q15 | BOs with 25%+ ownership by nationality | 📐 ✅ | Uses `with_significant_control` scope |
+| `a1203d` | a1203D | Q16 | Records BO residence? | ❓ | Setting |
+| `a1207o` | a1207O | Q17 | Foreign resident BOs (≥25%) by nationality | 📐 ✅ | Correctly filters: residence=MC, nationality≠MC, with significant control |
+| `a1210o` | a1210O | Q18 | Non-resident BOs (≥25%) by nationality | 📐 ⚠️ | Filters `residence_country NOT MC` — but "non-resident" means not resident in MC. The filter `where.not(residence_country: ["MC", nil, ""])` excludes unknown residence. Also doesn't explicitly mean "not in MC" — someone with residence_country "FR" is non-resident. This is approximately correct but could include people who are resident in MC if their residence_country field isn't "MC". |
+| `a1203` | a1203 | Q78 | Records dual nationality? | ❓ | Setting |
+| `ac171` | aC171 | Q80 | Had Monegasque clients (P&S) during period? | 🔧 | **On master:** `setting_value("ac171") || "Oui"` — always returns "Oui" by default. **Fixed in P1 PR:** derives from data. |
+
+### 1.9 HNWI and Transaction Statistics
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a11201bcd` | a11201BCD | Q19 | Has HNWI beneficial owners? | ✅ | Derived from data |
+| `a11201bcdu` | a11201BCDU | Q20 | Has UHNWI beneficial owners? | ✅ | Derived from data |
+| `a1105b` | a1105B | Q5 | Total transactions BY clients | ✅ | Correctly combines purchase/sale count + rental months ≥€10k |
+| `a1106b` | a1106B | Q6 | Total funds transferred BY clients | ⚠️ | Sums ALL transaction values. Q6 says "pour l'achat et la vente de biens immobiliers" — purchase/sale only. Should exclude rentals. |
+| `a1106brentals` | a1106BRENTALS | Q7 | Total funds for rentals | ✅ | Separate rental total |
+| `a1105w` | a1105W | Q8 | Total transactions WITH clients | ⚠️ | Just counts `with_client` transactions. Q8 covers purchases, sales AND rentals. But doesn't count rental months per AMSF definition (each month ≥€10k = 1 transaction). Undercounts rentals. |
+| `a1106w` | a1106W | Q9 | Total funds WITH clients | ✅ | Sums all with_client transaction values |
+
+### 1.10 Business Sector Statistics (Q81-Q109)
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a11502b` | a11502B | Q81 | MC clients in legal services | ⚠️ | `clients_by_sector("LEGAL_SERVICES")` counts ALL clients in that sector, not just Monegasque nationals. Section 1.11 title is "Monegasque Client Types - Purchases and Sales" — should filter by nationality=MC AND purchase/sale transactions. |
+| `a11602b` | a11602B | Q82 | MC clients in accounting | ⚠️ | Same issue — not filtered to MC nationals |
+| `a11702b` | a11702B | Q83 | MC clients: nominee shareholders | ⚠️ | Same |
+| `a11802b` | a11802B | Q84 | MC clients: bearer instruments | ⚠️ | Same |
+| `a12002b` | a12002B | Q85 | MC clients: real estate | ⚠️ | Same |
+| `a12102b` | a12102B | Q86 | MC clients: NMPPP | ⚠️ | Same |
+| `a12202b` | a12202B | Q87 | MC clients: TCSP | ⚠️ | Same |
+| `a12302b` | a12302B | Q88 | MC clients: multi-family office | ⚠️ | Same |
+| `a12302c` | a12302C | Q89 | MC clients: single-family office | ⚠️ | Same |
+| `a12402b` | a12402B | Q90 | MC clients: complex structures | ⚠️ | Same |
+| `a12502b` | a12502B | Q91 | MC clients: cash-intensive | ⚠️ | Same |
+| `a12602b` | a12602B | Q92 | MC clients: prepaid cards | ⚠️ | Same |
+| `a12702b` | a12702B | Q93 | MC clients: art/antiquities | ⚠️ | Same |
+| `a12802b` | a12802B | Q94 | MC clients: import/export | ⚠️ | Same |
+| `a12902b` | a12902B | Q95 | MC clients: high-value goods | ⚠️ | Same |
+| `a13002b` | a13002B | Q96 | MC clients: NPO | ⚠️ | Same |
+| `a13202b` | a13202B | Q97 | MC clients: gambling | ⚠️ | Same |
+| `a13302b` | a13302B | Q98 | MC clients: construction | ⚠️ | Same |
+| `a13402b` | a13402B | Q99 | MC clients: extractive | ⚠️ | Same |
+| `a13702b` | a13702B | Q100 | MC clients: defense/weapons | ⚠️ | Same |
+| `a13802b` | a13802B | Q101 | MC clients: yachting | ⚠️ | Same |
+| `a13902b` | a13902B | Q102 | MC clients: sports agents | ⚠️ | Same |
+| `a14102b` | a14102B | Q103 | MC clients: fund management | ⚠️ | Same |
+| `a14202b` | a14202B | Q104 | MC clients: holding company | ⚠️ | Same |
+| `a14302b` | a14302B | Q105 | MC clients: auctioneers | ⚠️ | Same |
+| `a14402b` | a14402B | Q106 | MC clients: car dealers | ⚠️ | Same |
+| `a14502b` | a14502B | Q107 | MC clients: government | ⚠️ | Same |
+| `a14602b` | a14602B | Q108 | MC clients: aircraft/jets | ⚠️ | Same |
+| `a14702b` | a14702B | Q109 | MC clients: transport | ⚠️ | Same |
+
+**Systemic bug: ALL 29 `clients_by_sector` methods fail to filter by Monegasque nationality.** Section 1.11 is titled "Types de clients monégasques - Achats et ventes." Every question asks for "clients uniques **monégasques**." The `clients_by_sector` helper needs a nationality filter.
+
+### 1.11 Comments and Misc
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a14801` | a14801 | Q110 | Has comments? | ✅ | Checks presence of setting |
+| `a14001` | a14001 | Q111 | Comment text | ❓ | Setting |
+| `air129` | aIR129 | Q31 | Purchases for Monaco residence? | ❓ | Setting |
+| `air1210` | aIR1210 | Q32 | Count of residence purchases | ❓ | Setting |
+| `a1801` | a1801 | Q21 | Has trust clients? | ✅ | Derived from data |
+| `a13601` | a13601 | Q22 | Provides other VASP services? | ❓ | Setting |
+| `a1402` | a1402 | Q79 | Secondary nationalities | ⚠️ | Returns empty hash `{}` — stub, not implemented |
+
+### 1.12 Dimensional Fields
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a1401` | a1401 | Q26 | Natural persons by nationality | 📐 ✅ | Correctly groups by nationality |
+| `a1501` | a1501 | Q33 | Legal entities by incorporation country | 📐 ✅ | |
+| `a11206b` | a11206B | Q38 | HNWI BOs by nationality | 📐 ✅ | |
+| `a112012b` | a112012B | Q39 | UHNWI BOs by nationality | 📐 ✅ | |
+| `a11302res` | a11302RES | Q50 | PEP clients by residence | 📐 ✅ | |
+| `a11302` | a11302 | Q51 | PEP clients by nationality | 📐 ✅ | |
+| `a11307` | a11307 | Q54 | PEP BOs by nationality | 📐 ✅ | |
+
+---
+
+## 2. Products & Services Risk (`products_services_risk.rb`)
+
+### 2.1 Check Payments
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a2101w` | a2101W | Q112 | Accepts check payments WITH clients? | ❓ | Setting |
+| `a2101wrp` | a2101WRP | Q113 | Accepted checks WITH clients in period? | ❓ | Setting |
+| `a2102w` | a2102W | Q114 | Check transactions WITH clients count | ✅ | |
+| `a2102bw` | a2102BW | Q115 | Check transactions WITH clients value | ✅ | |
+| `a2101b` | a2101B | Q116 | Clients made check payments? | ✅ | Derived from data |
+| `a2102b` | a2102B | Q117 | Check transactions BY clients count | ✅ | |
+| `a2102bb` | a2102BB | Q118 | Check transactions BY clients value | ✅ | |
+
+### 2.2 Transfer Payments
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a2104w` | a2104W | Q119 | Accepts wire transfers WITH clients? | ❓ | Setting |
+| `a2104wrp` | a2104WRP | Q120 | Accepted wire transfers in period? | ❓ | Setting |
+| `a2105w` | a2105W | Q121 | Wire transactions WITH clients count | ✅ | |
+| `a2105bw` | a2105BW | Q122 | Wire transactions WITH clients value | ✅ | |
+| `a2104b` | a2104B | Q123 | Clients made wire transfers? | ✅ | Derived from data |
+| `a2105b` | a2105B | Q124 | Wire transactions BY clients count | ✅ | |
+| `a2105bb` | a2105BB | Q125 | Wire transactions BY clients value | ✅ | |
+
+### 2.3 Cash Payments (WITH clients)
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a2107w` | a2107W | Q126 | Accepts cash WITH clients? | ❓ | Setting |
+| `a2107wrp` | a2107WRP | Q127 | Accepted cash in period? | ❓ | Setting |
+| `a2108w` | a2108W | Q128 | Cash transactions WITH clients count | ✅ | |
+| `a2109w` | a2109W | Q129 | Cash amount WITH clients | ✅ | |
+| `ag24010w` | aG24010W | Q130 | Value of cash in non-EUR currencies | ❌ | **Q130 asks for "valeur totale des fonds transférés... par paiements en espèces dans des devises autres que l'euro." Method sums ALL transaction_value by property_country — completely wrong. Should sum cash in non-EUR currencies WITH clients.** |
+| `a2110w` | a2110W | Q131 | Cash transactions ≥€10k WITH clients | ✅ | |
+| `a2113w` | a2113W | Q132 | Can distinguish cash >€100k? | ❓ | Setting |
+| `a2113aw` | a2113AW | Q133 | Cash >€100k with natural persons | ✅ | |
+| `a2114a` | a2114A | Q134 | Cash >€100k with MC legal entities | ✅ | |
+| `a2115aw` | a2115AW | Q135 | Cash >€100k with foreign legal entities | ✅ | |
+
+### 2.4 Cash Payments (BY clients)
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a2107b` | a2107B | Q136 | Clients made cash payments? | ✅ | Derived from data |
+| `a2108b` | a2108B | Q137 | Cash transactions BY clients count | ✅ | |
+| `a2109b` | a2109B | Q138 | Cash amount BY clients | ✅ | |
+| `ag24010b` | aG24010B | Q139 | Value of cash in non-EUR by clients | ❌ | **Same issue as ag24010w — sums transaction_value by property_country instead of non-EUR cash.** |
+| `a2110b` | a2110B | Q140 | Cash transactions ≥€10k BY clients | ✅ | |
+| `a2113b` | a2113B | Q141 | Can distinguish cash >€100k? | ❓ | Setting |
+| `a2113ab` | a2113AB | Q142 | Cash >€100k by natural persons | ✅ | |
+| `a2114ab` | a2114AB | Q143 | Cash >€100k by MC legal entities | ✅ | |
+| `a2115ab` | a2115AB | Q144 | Cash >€100k by foreign legal entities | ✅ | |
+
+### 2.5 Cryptocurrency
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a2201a` | a2201A | Q145 | Accept crypto with clients? | ❓ | Setting |
+| `a2201d` | a2201D | Q146 | Plan to accept crypto next year? | ❓ | Setting |
+| `a2202` | a2202 | Q147 | Business relationships with VA platforms? | ✅ | Derived from data |
+| `a2203` | a2203 | Q148 | Name the platforms | ❓ | Setting |
+| `ac1616c` | aC1616C | C65 | Clients use crypto for transactions? | ✅ | Same logic as a2202 |
+| `ac1621` | aC1621 | C66 | How entity verifies BO of virtual assets? | ❓ | Setting |
+
+### 2.6 Transaction Fields (Purchases & Sales)
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `air233b` | aIR233B | Q150 | Unique buyer clients | 🔧 | **On master:** counts transactions (not unique clients). **Fixed in PR #99:** `distinct.count(:client_id)` |
+| `air233s` | aIR233S | Q151 | Unique seller clients | 🔧 | **On master:** counts transactions. **Fixed in PR #99:** unique client count |
+| `air235b_2` | aIR235B_2 | Q153 | Total purchase/sale transactions | ✅ | |
+| `air235s` | aIR235S | Q154 | Sales transaction count | ✅ | |
+| `air117` | aIR117 | Q158 | Investment purchases (excluding primary residence) | 🔧 | **On master:** counts new construction purchases! **Fixed in PR #101:** filters `purchase_purpose: "INVESTMENT"` |
+| `air2391` | aIR2391 | Q159 | Preemption activity? | ❓ | Setting |
+| `air2392` | aIR2392 | Q160 | Number of preemptions | ❓ | Setting |
+| `air2393` | aIR2393 | Q161 | Value of preempted properties | ❓ | Setting |
+| `air234` | aIR234 | Q162 | Total unique rental properties | 🔧 | **On master:** `year_transactions.purchases.count` — counted purchases instead of rental properties! **Fixed in P1 PR:** uses `ManagedProperty` model. |
+| `air236` | aIR236 | Q163 | Total rental transactions | ✅ | |
+| `air2313` | aIR2313 | Q164 | Unique rental properties ≥€10k/month | ⚠️ | Uses `select(:client_id).distinct.count` — counts unique clients, not unique properties. Q164 asks for unique properties ("biens locatifs uniques"). Should count distinct properties. |
+| `air2316` | aIR2316 | Q165 | Unique rental properties <€10k/month | ⚠️ | Same issue — counts clients, not properties. |
+
+### 2.7 Dimensional Transaction Fields
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `air233` | aIR233 | Q149 | Transactions by property country | 📐 ⚠️ | Groups by `property_country` where `agency_role` is set. Q149 asks for "nombre total de clients uniques, ventilé par nationalité" — unique clients by nationality, not transactions by property country. |
+| `air235b_1` | aIR235B_1 | Q152 | Purchase/sale transactions by client country | 📐 ✅ | Correctly splits natural/legal entities by nationality/incorporation_country |
+| `air237b` | aIR237B | Q155 | 5-year purchase/sale transactions by client country | 🔧 | **On master:** counts rental transactions by property_country (wrong both in scope and grouping). **Fixed in PR #100:** 5-year lookback by client nationality. |
+| `air238b` | aIR238B | Q156 | Current year P&S funds by client country | 🔧 | **On master:** sums rental transaction_value by property_country. **Fixed in PR #100.** |
+| `air239b` | aIR239B | Q157 | 5-year P&S funds by client country | 🔧 | **On master:** sums rental_annual_value by property_country. **Fixed in PR #100.** |
+
+### 2.8 Comments
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a2501a` | a2501A | Q166 | Has comments? | ✅ | |
+| `a2501` | a2501 | Q167 | Comment text | ❓ | Setting |
+
+---
+
+## 3. Distribution Risk (`distribution_risk.rb`)
+
+### 3.1 Third-Party CDD
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a3101` | a3101 | Q168 | Uses local third-party CDD? | ✅ | Derived from data |
+| `a3102` | a3102 | Q169 | Local CDD clients by nationality | 📐 ✅ | |
+| `a3103` | a3103 | Q170 | Uses foreign third-party CDD? | ✅ | |
+| `a3104` | a3104 | Q171 | Foreign CDD clients by client nationality | 📐 ✅ | |
+| `a3105` | a3105 | Q172 | Foreign CDD by third-party country | 📐 ✅ | |
+| `ac1622f` | aC1622F | C56 | Uses third-party CDD? | ✅ | Combines a3101/a3103 |
+| `ac1622a` | aC1622A | C57 | Difficulties receiving CDD info? | ❓ | Setting |
+| `ac1622b` | aC1622B | C58 | Reason for difficulties | ❓ | Setting |
+
+### 3.2 Client Introduction
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a3201` | a3201 | Q180 | Accepts clients through introducers? | ✅ | Derived from data |
+| `a3501b` | a3501B | Q181 | Can provide introducer client nationality? | ✅ | Always "Oui" — reasonable |
+| `a3202` | a3202 | Q182 | Total introduced clients by nationality | 📐 ✅ | |
+| `a3204` | a3204 | Q183 | Introduced clients this year by nationality | 📐 ✅ | |
+| `a3501c` | a3501C | Q184 | Can provide introducer country? | ✅ | Always "Oui" |
+| `a3203` | a3203 | Q185 | Total introduced clients by introducer country | 📐 ✅ | |
+| `a3205` | a3205 | Q186 | This year's introduced clients by introducer country | 📐 ✅ | |
+
+### 3.3 New Clients / Onboarding
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ab3206` | aB3206 | Q173 | New unique natural person clients in period | 🔧 | **On master (in controls.rb):** returns training staff count! **Fixed in PR #102:** moved to distribution_risk, counts new natural person clients. |
+| `ab3207` | aB3207 | Q174 | New unique legal entity clients in period | 🔧 | **On master (in controls.rb):** returns setting or default 1! **Fixed in PR #102:** counts new legal entity clients. |
+| `a3208tola` | a3208TOLA | Q175 | New unique trust clients in period | 🔧 | **On master:** returns 0 (stub). **Fixed in PR #102:** counts new trust clients. |
+
+### 3.4 Non-Face-to-Face
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a3209` | a3209 | Q176 | Enters non-f2f relationships? | ❓ | Setting |
+| `a3210c` | a3210C | Q177 | New NP non-f2f clients count | ⚠️ | Returns 0 — stub, not implemented |
+| `a3211c` | a3211C | Q178 | New LE non-f2f clients count | ⚠️ | Returns 0 — stub |
+| `a3212ctola` | a3212CTOLA | Q179 | New trust non-f2f clients count | ⚠️ | Returns 0 — stub |
+| `a3210b` | a3210B | Q200 | Part of international group? | ❓ | Setting |
+| `a3211b` | a3211B | Q201 | Which group? | ❓ | Setting |
+| `a3210` | a3210 | Q202 | Member of professional association? | ❓ | Setting |
+| `a3211` | a3211 | Q203 | Which association? | ❓ | Setting |
+
+### 3.5 Marketing / Acquisition
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac1608` | aC1608 | C42 | Records accessible on demand? | ❓ | Setting |
+| `ac1631` | aC1631 | C36 | Records commercial register? | ❓ | Setting |
+| `ac1633` | aC1633 | C37 | Records statutes? | ❓ | Setting |
+| `ac1634` | aC1634 | C38 | Records meeting minutes? | ❓ | Setting |
+| `ac1630` | aC1630 | C33 | Other client info details | ❓ | Setting |
+| `ac1602` | aC1602 | C35 | Items not collected | ❓ | Setting |
+
+---
+
+## 4. Controls (`controls.rb`)
+
+### 4.1 Training & Staff
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ab3206` | aB3206 | Q173 | New NP clients | 🔧 | **WRONG on master** — returns training staff count. See distribution_risk notes. Fixed in PR #102 which moves this to distribution_risk. |
+| `ab3207` | aB3207 | Q174 | New LE clients | 🔧 | **WRONG on master** — returns setting. Fixed in PR #102. |
+| `ab1801b` | aB1801B | C70 (or C25) | Had AML training? | ✅ | Checks for training records |
+
+### 4.2 Compliance/Finances
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a381` | a381 | Q204 | Revenue for reporting period | ❓ | Setting |
+| `a3802` | a3802 | Q205 | Revenue in Monaco | ❓ | Setting |
+| `a3803` | a3803 | Q206 | Revenue outside Monaco | ❓ | Setting |
+| `a3804` | a3804 | Q207 | Last VAT declaration | ❓ | Setting |
+
+### 4.3 Due Diligence / Structure
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `air33lf` | aIR33LF | Q187 | Legal form of entity | ✅ | Returns XBRL-compliant label from setting |
+| `air328` | aIR328 | Q188 (C1) | Total employees/partners | ⚠️ | Returns "Oui"/"Non" based on whether simplified DD clients exist. But Q188/C1 asks for employee count. The YAML maps aIR328 to Q188 which asks "Veuillez indiquer le nombre total d'employés." But the method checks simplified DD. **Possible mismap — aIR328 might actually map to a different question about SDD existence.** |
+| `a3301` | a3301 | Q189 | SDD client count | ✅ | Counts clients with SIMPLIFIED DD level |
+| `a3302` | a3302 | Q190 | Has SDD clients? | ✅ | Derived from a3301 |
+| `a3303` | a3303 | Q191 | New SDD clients by nationality | 📐 ✅ | |
+| `a3304` | a3304 | Q192 | Entity has branches/subsidiaries? | ❓ | Setting |
+| `a3304c` | a3304C | Q193 (branches count?) | ⚠️ | Delegates to a3304 which returns Yes/No. But Q193 asks "Prière d'indiquer le nombre total de succursales" — should return a count. Returns Yes/No instead. However, YAML Q193 field is a3304C with no specific instruction. May be a gate question for "is entity a subsidiary of foreign entity." |
+| `a3305` | a3305 | Q194 | Parent company country | ❓ | Setting |
+| `a3306` | a3306 | Q195 | NP with enhanced DD by nationality | 📐 ✅ | |
+| `a3306a` | a3306A | Q196 | Shareholders ≥25% by nationality | 📐 ⚠️ | Returns empty hash — stub |
+| `a3306b` | a3306B | Q197 | Enhanced DD clients by residence | 📐 ✅ | |
+| `a3307` | a3307 | Q198 | Had significant changes in period? | ⚠️ | Checks if any legal entity clients have REINFORCED DD. Q198 asks about changes in management/shareholders/statutory changes to the ENTITY itself, not about client DD levels. Completely wrong semantic. |
+| `a3308` | a3308 | Q199 | Describe the changes | ❓ | Setting |
+
+### 4.4 Rejected/Terminated Relationships
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a3401` | a3401 | Q208 | Total rejected prospects (AML) | 🔧 | **On master:** `setting_value("a3401")&.to_i \|\| 12` — defaults to 12! **Fixed in P1 PR.** |
+| `a3402` | a3402 | Q209 | Can distinguish rejection reason? | ✅ | Setting, default "Oui" |
+| `a3403` | a3403 | Q210 | Rejections due to client attributes | 🔧 | **On master:** setting value. **Fixed in P1 PR:** derived from data. |
+| `a3414` | a3414 | Q211 | Total terminated relationships (AML) | 🔧 | **On master:** hardcoded 0. **Fixed in P1 PR:** derived from data. |
+| `a3415` | a3415 | Q212 | Can distinguish termination reason? | 🔧 | **On master:** default "Non". **Fixed in P1 PR:** default "Oui". |
+| `a3416` | a3416 | Q213 | Terminations due to client attributes | 🔧 | **On master:** setting value. **Fixed in P1 PR:** derived from data. |
+
+### 4.5 Comments (Section 3)
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `a3701a` | a3701A | Q214 | Has comments? | 🔧 | **On master:** `setting_value("a3701a") \|\| "Non"` — uses `\|\|` not `.present?`. **Fixed in P1 PR:** checks `.present?`. |
+| `a3701` | a3701 | Q215 | Comment text | ❓ | Setting |
+
+### 4.6 ID Verification & CDD Settings
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac1620` | aC1620 | C59 | Applies enhanced ID verification? | ❓ | Setting |
+| `ac1617` | aC1617 | C60 | Examines source of wealth? | ❓ | Setting |
+| `ac1625` | aC1625 | C28 | Records ID card info? | ❓ | Setting |
+| `ac1626` | aC1626 | C29 | Records passport info? | ❓ | Setting |
+| `ac1627` | aC1627 | C30 | Records residence permit? | ❓ | Setting |
+| `ac1629` | aC1629 | C32 | Records other info? | ❓ | Setting |
+| `ac1616b` | aC1616B | C61 | High-risk CDD frequency | ❓ | Setting |
+| `ac1616a` | aC1616A | C62 | Standard CDD frequency | ❓ | Setting |
+| `ac1618` | aC1618 | C63 | Other high-risk measures? | ❓ | Setting |
+| `ac1619` | aC1619 | C64 | Describe other measures | ❓ | Setting |
+
+### 4.7 SAR (Suspicious Activity Reports)
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac1102a` | aC1102A | C1 | Total employees (repeat Q188) | ⚠️ | **Counts STR reports, not employees!** Q C1 says "Veuillez indiquer le nombre total d'employés." The method counts `str_reports` for the year. This is completely wrong — it answers a different question (SAR count). |
+| `ac1102` | aC1102 | C2 | FTE employees | ❓ | Setting — `setting_value("total_employees")` |
+| `ac1101z` | aC1101Z | C3 | Hours spent on AML compliance | ❓ | Setting |
+
+**Note:** The Q173 PR (#102) identified that `ac1102a` and `ac1102` were confused with `ab3206` and `ab3207`. On master, `ab3206` (in controls.rb) returns training staff count, and `ac1102a` counts STR reports. The PR moves `ab3206`/`ab3207` to distribution_risk for Q173/Q174, but does NOT fix `ac1102a`'s semantic to return employee count. **`ac1102a` is still broken on the feature branch.**
+
+### 4.8 SAR Breakdowns & Sanctions
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac11101` | aC11101 | C80 | Keeps transaction records 5+ years? | ❓ | Setting |
+| `ac11102` | aC11102 | C81 | Keeps CDD records 5+ years? | ❓ | Setting |
+| `ac11103` | aC11103 | C82 | Records in safe location? | ❓ | Setting |
+| `ac11104` | aC11104 | C83 | Records available to authorities? | ❓ | Setting |
+| `ac11105` | aC11105 | C84 | Has data backup/recovery plan? | ❓ | Setting |
+| `ac114` | aC114 | C4 | Has board/senior management? | ❓ | Setting |
+| `ac11401` | aC11401 | C97 | Accepts cash with clients? | ❓ | Setting |
+| `ac11402` | aC11402 | C98 | Has specific cash AML controls? | ❓ | Setting |
+| `ac11403` | aC11403 | C99 | Describe cash controls | ❓ | Setting |
+| `ac11501b` | aC11501B | C100 | Has filed SARs in period? | ❓ | Setting |
+| `ac11502` | aC11502 | C101 | TF-related SARs count | ❓ | Setting |
+| `ac11504` | aC11504 | C102 | ML-related SARs count | ❓ | Setting |
+| `ac11508` | aC11508 | C103 | Measures to improve SAR filing? | ❓ | Setting |
+| `ac1106` | aC1106 | C5 | Has compliance service? | ❓ | Setting |
+
+### 4.9 AML System & Policies
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac1501` | aC1501 | C25 | Had AML training for directors? | ❓ | Setting |
+| `ac1503b` | aC1503B | C26 | Had AML training for staff? | ❓ | Setting |
+| `ac1506` | aC1506 | C27 | Total employees trained | ❓ | Setting |
+| `ac1518a` | aC1518A | C6 | Part of a group? | ❓ | Setting |
+| `ac1201` | aC1201 | C7 | Has documented AML policies? | ❓ | Setting |
+| `ac1202` | aC1202 | C8 | Policies approved by board? | ❓ | Setting |
+| `ac1203` | aC1203 | C9 | Policies distributed to employees? | ❓ | Setting |
+| `ac1204` | aC1204 | C10 | Employees aware of policies? | ❓ | Setting |
+| `ac1205` | aC1205 | C11 | Updated policies this year? | ❓ | Setting |
+| `ac1206` | aC1206 | C12 | Last policy update date | ❓ | Setting |
+| `ac1207` | aC1207 | C13 | Systematic change tracking? | ❓ | Setting |
+| `ac1209b` | aC1209B | C14 | Group-wide AML program? | ❓ | Setting |
+| `ac1209c` | aC1209C | C15 | Group program compliant with MC law? | ❓ | Setting |
+| `ac1208` | aC1208 | C16 | Who prepared policies? | ❓ | Setting |
+| `ac1209` | aC1209 | C17 | Self-assessment of AML adequacy? | ❓ | Setting |
+
+### 4.10 Governance
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac1301` | aC1301 | C18 | Board demonstrates AML responsibility? | ❓ | Setting |
+| `ac1302` | aC1302 | C19 | Board receives AML reports? | ❓ | Setting |
+| `ac1303` | aC1303 | C20 | Board ensures AML gaps corrected? | ❓ | Setting |
+| `ac1304` | aC1304 | C21 | Senior management approves high-risk clients? | ❓ | Setting |
+
+### 4.11 Violations
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac1401` | aC1401 | C22 | AML violations in last 5 years? | ❓ | Setting |
+| `ac1402` | aC1402 | C23 | Total violations count | ❓ | Setting |
+| `ac1403` | aC1403 | C24 | Number and type of violations | ❓ | Setting |
+
+### 4.12 Record Retention / Comments
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac116a` | aC116A | C104 | Has comments on controls? | 🔧 | **On master:** `setting_value("ac116a") \|\| "Oui"` — defaults to "Oui". **Fixed in P1 PR:** `.present?` check. |
+| `ac11601` | aC11601 | C105 | Comment text | ❓ | Setting |
+
+### 4.13 Audit
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac11201` | aC11201 | C85 | TFS policies adequate? | ❓ | Setting |
+| `ac1125a` | aC1125A | C86 | Consults national freeze list? | ❓ | Setting |
+| `ac11301` | aC11301 | C90 | Determines if clients are PEPs? | ❓ | Setting |
+| `ac11302` | aC11302 | C91 | Measures to identify PEPs | ❓ | Setting |
+| `ac11303` | aC11303 | C92 | Additional PEP procedures | ❓ | Setting |
+| `ac11304` | aC11304 | C93 | PEP screening for new clients? | ❓ | Setting |
+| `ac11305` | aC11305 | C94 | Ongoing PEP screening? | ❓ | Setting |
+| `ac11306` | aC11306 | C95 | Enhanced PEP monitoring? | ❓ | Setting |
+| `ac11307` | aC11307 | C96 | All PEPs treated as high-risk? | ❓ | Setting |
+| `ac12236` | aC12236 | C88 | TF declarations to DBT | ❓ | Setting |
+| `ac12237` | aC12237 | C89 | WMD declarations to DBT | ❓ | Setting |
+| `ac12333` | aC12333 | C87 | Identified TF/WMD persons/transactions? | ❓ | Setting |
+
+---
+
+## 5. Signatories (`signatories.rb`)
+
+| Method | Field ID | Q# | Question Summary | Status | Notes |
+|--------|----------|----|-----------------|--------|-------|
+| `ac1701` | aC1701 | C67 | EDD clients at onboarding | 🔧 | **On master:** `setting_value("legal_form")&.to_i \|\| 0` — returns legal form as integer! **Fixed in P1 PR:** counts REINFORCED DD new clients. |
+| `ac1702` | aC1702 | C68 | EDD clients during relationship | 🔧 | **On master:** `setting_value("registration_number")&.to_i \|\| 0` — returns registration number! **Fixed in P1 PR:** counts all REINFORCED DD clients. |
+| `ac1703` | aC1703 | C69 | % of clients with EDD | 🔧 | **On master:** `setting_value("registration_date")` — returns a date string! **Fixed in P1 PR:** calculates percentage. |
+| `ac1601` | aC1601 | C34 | All CDD info kept on file? | ❓ | Setting |
+| `ac168` | aC168 | C31 | Records proof of address? | ❓ | Setting |
+| `ac1635` | aC1635 | C39 | Records BO ID documents? | ❓ | Setting |
+| `ac1635a` | aC1635A | C43 | Records stored systematically? | ❓ | Setting |
+| `ac1636` | aC1636 | C40 | Records other LE data? | ❓ | Setting |
+| `ac1637` | aC1637 | C41 | Specify other LE data | ❓ | Setting |
+| `ac1638a` | aC1638A | C44 | Summary records kept? | ❓ | Setting |
+| `ac1639a` | aC1639A | C45 | Info in database? | ❓ | Setting |
+| `ac1641a` | aC1641A | C46 | Uses CDD tools? | ❓ | Setting |
+| `ac1640a` | aC1640A | C47 | Which tools? | ❓ | Setting |
+| `ac1642a` | aC1642A | C48 | CDD tool results stored? | ❓ | Setting |
+| `ac1801` | aC1801 | C71 | Risk scoring levels | ❓ | Setting |
+| `ac1611` | aC1611 | C51 | Total unique clients (repeat Q4) | ⚠️ | Uses `organization.clients.count` — same issue as a1101. Not filtered by `kept` or activity. |
+| `ac1802` | aC1802 | C72 | High-risk client count | ✅ | Counts clients with `risk_level: "high"` |
+| `ac1806` | aC1806 | C73 | All risk factors considered? | ❓ | Setting |
+| `ac1609` | aC1609 | C49 | Risk-based CDD approach? | ❓ | Setting |
+| `ac1610` | aC1610 | C50 | CDD level policies? | ❓ | Setting |
+| `ac1612a` | aC1612A | C52 | Has SDD clients? | ❓ | Setting |
+| `ac1612` | aC1612 | C53 | SDD client count | ❓ | Setting |
+| `ac1614` | aC1614 | C54 | Verifies all clients with reliable info? | ❓ | Setting |
+| `ac1615` | aC1615 | C55 | CDD includes acceptance procedures? | ❓ | Setting |
+| `ac1812` | aC1812 | C76 | Uses sensitive country list? | ❓ | Setting |
+| `ac1813` | aC1813 | C77 | Uses sensitive activity list? | ❓ | Setting |
+| `ac1814w` | aC1814W | C78 | Examines ML/TF risks separately? | ❓ | Setting |
+| `ac1807` | aC1807 | C74 | Risk factors description | ❓ | Setting |
+| `ac1811` | aC1811 | C75 | Uses sensitive country list? | ❓ | Setting |
+| `ac1904` | aC1904 | C79 | Last SICCFIN audit date | ❓ | Setting |
+| `as1` | aS1 | S1 | Signatory attestation 1 | ❓ | Setting |
+| `as2` | aS2 | S2 | Signatory attestation 2 | ❓ | Setting |
+| `aincomplete` | aINCOMPLETE | S3 | Incomplete submission reason | ❓ | Setting |
+| `amles` | aMLES | Q37 | MC legal entities by type | 🔧 | **On master:** `clients_kept.legal_entities.count` — returns total LE count, not filtered to MC, not grouped by type. **Fixed in P1 PR:** MC-only, grouped by legal_entity_type. |
+
+---
+
+## Summary Statistics
+
+### By Module
+
+| Module | Total Methods | ✅ Correct | ⚠️ Partial | ❌ Wrong | 🔧 Fixed in PR | ❓ Setting | 📐 Dimensional |
+|--------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Customer Risk** | 87 | 33 | 38 | 0 | 1 | 12 | 18 |
+| **Products/Services** | 51 | 24 | 4 | 2 | 7 | 15 | 3 |
+| **Distribution Risk** | 25 | 10 | 3 | 0 | 3 | 9 | 5 |
+| **Controls** | 75 | 3 | 2 | 0 | 8 | 62 | 1 |
+| **Signatories** | 35 | 1 | 1 | 0 | 4 | 29 | 0 |
+| **TOTAL** | **273** | **71** | **48** | **2** | **23** | **127** | **27** |
+
+### Bug Severity Summary
+
+| Category | Count | Details |
+|----------|-------|---------|
+| 🔧 **Fixed in PRs** | 23 | P1 audit (12), Q150-Q151 (2), Q155-Q157 (3), Q158 (1), Q173-Q175 (3), misc defaults (2) |
+| ❌ **Wrong** | 2 | `ag24010w` and `ag24010b` — non-EUR cash questions return irrelevant property country sums |
+| ⚠️ **Partially correct / Missing filter** | 48 | See details below |
+| ❓ **Setting values** | 127 | Can't audit without seeing org settings UI |
+| ✅ **Correct** | 71 | Verified against French questionnaire |
+
+### Critical Issues (Unfixed)
+
+1. **`ag24010w` / `ag24010b` (Q130/Q139)** — ❌ Ask for non-EUR cash amounts, return property location sums
+2. **29 `clients_by_sector` methods (Q81-Q109)** — ⚠️ Missing Monegasque nationality filter. These count ALL clients in a sector, not just MC nationals as the questions require.
+3. **`a1101` / `ac1611` (Q4/C51)** — ⚠️ Count all organization clients, not filtered by `kept` scope or reporting year activity
+4. **`a1102`/`a1103`/`a1104` (Q23-Q25)** — ⚠️ Not filtered to natural persons as questions specify
+5. **`a1106b` (Q6)** — ⚠️ Includes rental transaction values; Q6 asks for P&S only
+6. **`a1404b` (Q28)** — ⚠️ Includes all transactions; Q28 asks for P&S only
+7. **`a1502b` (Q34)** — ⚠️ Includes rental months; Q34 asks for P&S only
+8. **`a1503b` (Q35)** — ⚠️ Includes rentals; Q35 asks for P&S only
+9. **`a1806tola` (Q46)** / `a1807tola` (Q47) — ⚠️ Include rentals; Q46-Q47 ask for P&S only
+10. **`a11304b` (Q52)** / `a11305b` (Q53) — ⚠️ Include all transactions; should be P&S only
+11. **`a1105w` (Q8)** — ⚠️ Doesn't count rental months per AMSF definition
+12. **`air233` (Q149)** — ⚠️ Returns transactions by property country; Q149 asks for unique clients by nationality
+13. **`air2313` / `air2316` (Q164/Q165)** — ⚠️ Count unique clients, not unique properties
+14. **`a3307` (Q198)** — ⚠️ Checks if LE clients have reinforced DD; Q198 asks about entity's own management changes
+15. **`ac1102a` (C1)** — ⚠️ Counts STR reports instead of employees (even on feature branch)
+16. **`a1402` (Q79)** — ⚠️ Returns empty hash (stub)
+17. **`a3210c`/`a3211c`/`a3212ctola` (Q177-Q179)** — ⚠️ Return 0 (stubs)
+18. **`a3306a` (Q196)** — ⚠️ Returns empty hash (stub)
+
+### Overall Bug Rate
+
+Excluding settings (❓) and already-fixed items (🔧):
+
+- **Auditable computed methods:** 273 - 127 (settings) - 23 (fixed) = **123 methods**
+- **Correct:** 71
+- **Partially wrong or wrong:** 50 (48 ⚠️ + 2 ❌)
+- **Bug rate on computed methods: 40.7%** (50/123)
+
+If we weight by severity (❌ = definitely wrong, ⚠️ = missing filter or stub):
+- **Hard bugs (❌):** 2
+- **Filter/scope bugs (⚠️, systemic):** ~35 (29 sector + 3 client type + 3 P&S filter)
+- **Stub/not implemented (⚠️):** ~7
+- **Other (⚠️):** ~6
+
+### Priority Fix Recommendations
+
+1. **P0 — Systemic sector filter** (29 methods): Add `where(nationality: "MC")` to `clients_by_sector` helper. One-line fix affects 29 fields.
+2. **P0 — ag24010w/ag24010b**: Completely wrong. Need non-EUR cash tracking or stub.
+3. **P1 — P&S-only filters** (~8 methods): Add `.where(transaction_type: %w[PURCHASE SALE])` to a1106b, a1404b, a1502b, a1503b, a1806tola, a1807tola, a11304b, a11305b.
+4. **P1 — Client type filters** (3 methods): Add `.natural_persons` to a1102, a1103, a1104.
+5. **P1 — ac1102a**: Fix to return employee count instead of STR count.
+6. **P1 — a3307**: Fix to check entity's own management changes (setting), not client DD.
+7. **P2 — Stubs**: Implement a1402, a3210c/a3211c/a3212ctola, a3306a when data models support them.
+8. **P2 — air233 (Q149)**: Change from transactions-by-property-country to unique-clients-by-nationality.
+9. **P2 — air2313/air2316**: Change from client-based to property-based counting.

--- a/test/models/survey/fields/audit_round_2_test.rb
+++ b/test/models/survey/fields/audit_round_2_test.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Survey::Fields::AuditRound2Test < ActiveSupport::TestCase
+  setup do
+    @account = Account.create!(owner: users(:one), name: "Round 2 Test Account", personal: false)
+    @org = Organization.create!(account: @account, name: "Round 2 Agency", rci_number: "R2001")
+    @survey = Survey.new(organization: @org, year: 2025)
+  end
+
+  # === a1101 — uses clients_kept (non-discarded) ===
+
+  test "a1101 counts only non-discarded clients" do
+    c1 = Client.create!(organization: @org, name: "Active", client_type: "NATURAL_PERSON")
+    c2 = Client.create!(organization: @org, name: "Discarded", client_type: "NATURAL_PERSON")
+    c2.discard
+
+    assert_equal 1, @survey.send(:a1101)
+  end
+
+  # === a1102/a1103/a1104 — natural persons only ===
+
+  test "a1102 counts only natural person MC nationals" do
+    Client.create!(organization: @org, name: "NP MC", client_type: "NATURAL_PERSON", nationality: "MC")
+    Client.create!(organization: @org, name: "LE MC", client_type: "LEGAL_ENTITY", legal_entity_type: "SAM", nationality: "MC")
+
+    assert_equal 1, @survey.send(:a1102)
+  end
+
+  test "a1103 counts only natural person foreign residents" do
+    Client.create!(organization: @org, name: "NP FR Res", client_type: "NATURAL_PERSON", nationality: "FR", residence_status: "RESIDENT")
+    Client.create!(organization: @org, name: "LE FR Res", client_type: "LEGAL_ENTITY", legal_entity_type: "SARL", nationality: "FR", residence_status: "RESIDENT")
+
+    assert_equal 1, @survey.send(:a1103)
+  end
+
+  test "a1104 counts only natural person non-residents" do
+    Client.create!(organization: @org, name: "NP NonRes", client_type: "NATURAL_PERSON", residence_status: "NON_RESIDENT")
+    Client.create!(organization: @org, name: "LE NonRes", client_type: "LEGAL_ENTITY", legal_entity_type: "SAM", residence_status: "NON_RESIDENT")
+
+    assert_equal 1, @survey.send(:a1104)
+  end
+
+  # === a1106b — purchase/sale only ===
+
+  test "a1106b excludes rental values" do
+    client = Client.create!(organization: @org, name: "Client", client_type: "NATURAL_PERSON")
+    Transaction.create!(organization: @org, client: client, transaction_type: "PURCHASE", direction: "BY_CLIENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: client, transaction_type: "RENTAL", direction: "BY_CLIENT", transaction_date: Date.new(2025, 4, 1), transaction_value: 15_000)
+
+    assert_equal 500_000, @survey.send(:a1106b)
+  end
+
+  # === a1105w — counts rental months per AMSF definition ===
+
+  test "a1105w counts rental months for qualifying rentals" do
+    client = Client.create!(organization: @org, name: "Client", client_type: "NATURAL_PERSON")
+    Transaction.create!(organization: @org, client: client, transaction_type: "PURCHASE", direction: "WITH_CLIENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: client, transaction_type: "RENTAL", direction: "WITH_CLIENT", transaction_date: Date.new(2025, 4, 1), transaction_value: 12_000, rental_duration_months: 6)
+
+    # 1 purchase + 6 rental months = 7
+    assert_equal 7, @survey.send(:a1105w)
+  end
+
+  test "a1105w excludes rental months under 10k" do
+    client = Client.create!(organization: @org, name: "Client", client_type: "NATURAL_PERSON")
+    Transaction.create!(organization: @org, client: client, transaction_type: "RENTAL", direction: "WITH_CLIENT", transaction_date: Date.new(2025, 4, 1), transaction_value: 8_000, rental_duration_months: 12)
+
+    assert_equal 0, @survey.send(:a1105w)
+  end
+
+  # === a1404b — natural person funds, P&S only ===
+
+  test "a1404b excludes rental values for natural persons" do
+    np = Client.create!(organization: @org, name: "NP", client_type: "NATURAL_PERSON")
+    Transaction.create!(organization: @org, client: np, transaction_type: "PURCHASE", direction: "BY_CLIENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 300_000)
+    Transaction.create!(organization: @org, client: np, transaction_type: "RENTAL", direction: "BY_CLIENT", transaction_date: Date.new(2025, 4, 1), transaction_value: 12_000)
+
+    assert_equal 300_000, @survey.send(:a1404b)
+  end
+
+  # === a1502b — LE transactions, P&S only (no rental months) ===
+
+  test "a1502b counts only purchase/sale for legal entities" do
+    le = Client.create!(organization: @org, name: "SARL", client_type: "LEGAL_ENTITY", legal_entity_type: "SARL")
+    Transaction.create!(organization: @org, client: le, transaction_type: "PURCHASE", direction: "BY_CLIENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: le, transaction_type: "RENTAL", direction: "BY_CLIENT", transaction_date: Date.new(2025, 5, 1), transaction_value: 15_000, rental_duration_months: 12)
+
+    assert_equal 1, @survey.send(:a1502b)
+  end
+
+  # === a1503b — LE funds, P&S only ===
+
+  test "a1503b sums only purchase/sale funds for legal entities" do
+    le = Client.create!(organization: @org, name: "SARL", client_type: "LEGAL_ENTITY", legal_entity_type: "SARL")
+    Transaction.create!(organization: @org, client: le, transaction_type: "PURCHASE", direction: "BY_CLIENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: le, transaction_type: "RENTAL", direction: "BY_CLIENT", transaction_date: Date.new(2025, 5, 1), transaction_value: 15_000)
+
+    assert_equal 500_000, @survey.send(:a1503b)
+  end
+
+  # === a1806tola — trust transactions, P&S only ===
+
+  test "a1806tola counts only purchase/sale for trusts" do
+    trust = Client.create!(organization: @org, name: "Trust", client_type: "LEGAL_ENTITY", legal_entity_type: "TRUST")
+    Transaction.create!(organization: @org, client: trust, transaction_type: "SALE", direction: "BY_CLIENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 1_000_000)
+    Transaction.create!(organization: @org, client: trust, transaction_type: "RENTAL", direction: "BY_CLIENT", transaction_date: Date.new(2025, 5, 1), transaction_value: 20_000)
+
+    assert_equal 1, @survey.send(:a1806tola)
+  end
+
+  # === a1807tola — trust funds, P&S only ===
+
+  test "a1807tola sums only purchase/sale funds for trusts" do
+    trust = Client.create!(organization: @org, name: "Trust", client_type: "LEGAL_ENTITY", legal_entity_type: "TRUST")
+    Transaction.create!(organization: @org, client: trust, transaction_type: "SALE", direction: "BY_CLIENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 1_000_000)
+    Transaction.create!(organization: @org, client: trust, transaction_type: "RENTAL", direction: "BY_CLIENT", transaction_date: Date.new(2025, 5, 1), transaction_value: 20_000)
+
+    assert_equal 1_000_000, @survey.send(:a1807tola)
+  end
+
+  # === a11304b / a11305b — PEP, P&S only ===
+
+  test "a11304b counts only purchase/sale for PEP clients" do
+    pep = Client.create!(organization: @org, name: "PEP", client_type: "NATURAL_PERSON", is_pep: true, pep_type: "DOMESTIC")
+    Transaction.create!(organization: @org, client: pep, transaction_type: "PURCHASE", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+    Transaction.create!(organization: @org, client: pep, transaction_type: "RENTAL", transaction_date: Date.new(2025, 5, 1), transaction_value: 15_000)
+
+    assert_equal 1, @survey.send(:a11304b)
+  end
+
+  test "a11305b sums only purchase/sale funds for PEP clients" do
+    pep = Client.create!(organization: @org, name: "PEP", client_type: "NATURAL_PERSON", is_pep: true, pep_type: "DOMESTIC")
+    Transaction.create!(organization: @org, client: pep, transaction_type: "SALE", transaction_date: Date.new(2025, 3, 1), transaction_value: 800_000)
+    Transaction.create!(organization: @org, client: pep, transaction_type: "RENTAL", transaction_date: Date.new(2025, 5, 1), transaction_value: 15_000)
+
+    assert_equal 800_000, @survey.send(:a11305b)
+  end
+
+  # === clients_by_sector — MC nationality filter ===
+
+  test "clients_by_sector only counts Monegasque nationals" do
+    Client.create!(organization: @org, name: "MC Lawyer", client_type: "NATURAL_PERSON", nationality: "MC", business_sector: "LEGAL_SERVICES")
+    Client.create!(organization: @org, name: "FR Lawyer", client_type: "NATURAL_PERSON", nationality: "FR", business_sector: "LEGAL_SERVICES")
+
+    assert_equal 1, @survey.send(:a11502b)
+  end
+
+  # === ag24010w / ag24010b — stub returning 0 ===
+
+  test "ag24010w returns 0 until cash_currency is supported" do
+    client = Client.create!(organization: @org, name: "Client", client_type: "NATURAL_PERSON")
+    Transaction.create!(organization: @org, client: client, transaction_type: "PURCHASE", direction: "WITH_CLIENT", transaction_date: Date.new(2025, 3, 1), transaction_value: 500_000)
+
+    assert_equal 0, @survey.send(:ag24010w)
+  end
+
+  test "ag24010b returns 0 until cash_currency is supported" do
+    assert_equal 0, @survey.send(:ag24010b)
+  end
+
+  # === air233 — unique clients by nationality ===
+
+  test "air233 groups clients by nationality" do
+    Client.create!(organization: @org, name: "MC Client", client_type: "NATURAL_PERSON", nationality: "MC")
+    Client.create!(organization: @org, name: "FR Client", client_type: "NATURAL_PERSON", nationality: "FR")
+    Client.create!(organization: @org, name: "FR Client 2", client_type: "NATURAL_PERSON", nationality: "FR")
+
+    result = @survey.send(:air233)
+    assert_equal 1, result["MC"]
+    assert_equal 2, result["FR"]
+  end
+
+  test "air233 includes legal entities by incorporation country" do
+    Client.create!(organization: @org, name: "MC Company", client_type: "LEGAL_ENTITY", legal_entity_type: "SAM", incorporation_country: "MC")
+
+    result = @survey.send(:air233)
+    assert_equal 1, result["MC"]
+  end
+
+  # === air2313 / air2316 — count properties not clients ===
+
+  test "air2313 counts managed properties with rent >= 10k" do
+    client = Client.create!(organization: @org, name: "Landlord", client_type: "NATURAL_PERSON")
+    ManagedProperty.create!(organization: @org, client: client, property_address: "1 Rue Grimaldi", management_start_date: Date.new(2024, 1, 1), monthly_rent: 15_000, management_fee_percent: 5)
+    ManagedProperty.create!(organization: @org, client: client, property_address: "2 Rue Grimaldi", management_start_date: Date.new(2024, 1, 1), monthly_rent: 8_000, management_fee_percent: 5)
+
+    assert_equal 1, @survey.send(:air2313)
+  end
+
+  test "air2316 counts managed properties with rent < 10k" do
+    client = Client.create!(organization: @org, name: "Landlord", client_type: "NATURAL_PERSON")
+    ManagedProperty.create!(organization: @org, client: client, property_address: "1 Rue Grimaldi", management_start_date: Date.new(2024, 1, 1), monthly_rent: 15_000, management_fee_percent: 5)
+    ManagedProperty.create!(organization: @org, client: client, property_address: "2 Rue Grimaldi", management_start_date: Date.new(2024, 1, 1), monthly_rent: 8_000, management_fee_percent: 5)
+
+    assert_equal 1, @survey.send(:air2316)
+  end
+
+  test "air2313 excludes properties not active in survey year" do
+    client = Client.create!(organization: @org, name: "Landlord", client_type: "NATURAL_PERSON")
+    ManagedProperty.create!(organization: @org, client: client, property_address: "Old Prop", management_start_date: Date.new(2020, 1, 1), management_end_date: Date.new(2023, 12, 31), monthly_rent: 15_000, management_fee_percent: 5)
+
+    assert_equal 0, @survey.send(:air2313)
+  end
+
+  # === ac1102a — employee count from setting ===
+
+  test "ac1102a returns employee count from setting" do
+    assert_equal 0, @survey.send(:ac1102a)
+  end
+
+  # === a3307 — setting value ===
+
+  test "a3307 returns setting value defaulting to Non" do
+    assert_equal "Non", @survey.send(:a3307)
+  end
+
+  # === ac1611 — uses clients_kept ===
+
+  test "ac1611 counts only non-discarded clients" do
+    c1 = Client.create!(organization: @org, name: "Active", client_type: "NATURAL_PERSON")
+    c2 = Client.create!(organization: @org, name: "Discarded", client_type: "NATURAL_PERSON")
+    c2.discard
+
+    assert_equal 1, @survey.send(:ac1611)
+  end
+end

--- a/test/models/survey_to_hash_test.rb
+++ b/test/models/survey_to_hash_test.rb
@@ -25,10 +25,10 @@ class SurveyToHashTest < ActiveSupport::TestCase
   end
 
   test "to_hash includes calculated values" do
-    # a1101 is total clients - should be calculated from organization.clients.count
+    # a1101 is total active (non-discarded) clients
     result = @survey.to_hash
 
-    expected_count = @organization.clients.count
+    expected_count = @organization.clients.kept.count
     assert_equal expected_count, result["a1101"]
   end
 end


### PR DESCRIPTION
## Systematic audit round 2

Cross-referenced every computed survey method against the French AMSF questionnaire text. 15 semantic bugs fixed:

### Customer Risk (11 fixes)
- **a1101/ac1611**: Use `clients_kept` (non-discarded) instead of `organization.clients`
- **a1102/a1103/a1104** (Q23-Q25): Filter to natural persons only
- **a1106b** (Q6): Restrict to purchase/sale only
- **a1404b** (Q28): Add P&S filter for natural person funds
- **a1502b** (Q34): Remove rental months from LE transaction count
- **a1503b** (Q35): Add P&S filter for LE funds
- **a1806tola** (Q46): Remove rental months from trust transaction count
- **a1807tola** (Q47): Add P&S filter for trust funds
- **a11304b/a11305b** (Q52-Q53): Add P&S filter for PEP stats
- **a1105w** (Q8): Count rental months per AMSF definition

### Helpers (1 fix)
- **clients_by_sector** (Q81-Q109): Add Monegasque nationality filter — affects 29 sector methods

### Products & Services (4 fixes)
- **ag24010w/ag24010b** (Q130/Q139): Stub to 0 (need `cash_currency` column for non-EUR tracking)
- **air233** (Q149): Return clients by nationality instead of transactions by property country
- **air2313/air2316** (Q164/Q165): Count managed properties instead of unique clients

### Controls (2 fixes)
- **ac1102a** (C1): Return employee count from setting instead of STR report count
- **a3307** (Q198): Use setting (entity management changes) instead of client DD check

### Also included
- `docs/full_survey_audit.md` — complete 700-line audit of all 273 survey methods
- 25 new tests, all passing
- Zero regressions vs master (23 failures + 11 errors are pre-existing)