### PR TITLE
Fix aC1201/aC1208 conditional: default aC1208 when aC1201 is Oui

### DIFF
--- a/app/models/survey/fields/controls.rb
+++ b/app/models/survey/fields/controls.rb
@@ -399,7 +399,14 @@ class Survey
       end
 
       def ac1208
-        setting_value("compliance_policies_author")
+        raw = setting_value("compliance_policies_author")
+
+        # XBRL rule: if aC1201 is "Oui", aC1208 must be present
+        if raw.blank? && ac1201 == "Oui"
+          return "Par l\u2019entit\u00e9"
+        end
+
+        raw
       end
 
       def ac1209


### PR DESCRIPTION
XBRL validation requires aC1208 to be present when aC1201 is `Oui`. aC1201 defaults to `Oui` but aC1208 could be nil when the setting is not configured.

Now defaults to `Par l'entité` as a safe fallback when aC1201 is `Oui` and no value is stored.